### PR TITLE
Serializing Journals

### DIFF
--- a/WizardMakerTestbed/Form1.cs
+++ b/WizardMakerTestbed/Form1.cs
@@ -76,17 +76,17 @@ namespace WizardMakerTestbed
             this.TheButton.Click += new EventHandler( OnTheButtonClicked );
 
             #region GridForAbilities
-            bindingListOfAbilityInstances.Add( new AbilityInstance( ArchAbility.Brawl,  30, "Dodging"          ) );
-            bindingListOfAbilityInstances.Add( new AbilityInstance( ArchAbility.Awareness,  15, "At night",         NO_AFF, PUI, 2 ) );
-            bindingListOfAbilityInstances.Add( new AbilityInstance( ArchAbility.Charm,  4, "First impressions"                ) );
-            bindingListOfAbilityInstances.Add( new AbilityInstance( ArchAbility.FolkKen,  50, "Motivations",      AFF, NO_PUI    ) );
-            bindingListOfAbilityInstances.Add( new AbilityInstance( ArchAbility.Guile,  6, "Not lying"        ) );
+            bindingListOfAbilityInstances.Add( new AbilityInstance( ArchAbility.Brawl,  AbilityInstance.createID(), 30, "Dodging"          ) );
+            bindingListOfAbilityInstances.Add( new AbilityInstance( ArchAbility.Awareness, AbilityInstance.createID(), 15, "At night",         NO_AFF, PUI, 2 ) );
+            bindingListOfAbilityInstances.Add( new AbilityInstance( ArchAbility.Charm, AbilityInstance.createID(), 4, "First impressions"                ) );
+            bindingListOfAbilityInstances.Add( new AbilityInstance( ArchAbility.FolkKen,  AbilityInstance.createID(), 50, "Motivations",      AFF, NO_PUI    ) );
+            bindingListOfAbilityInstances.Add( new AbilityInstance( ArchAbility.Guile,  AbilityInstance.createID(), 6, "Not lying"        ) );
 
-            bindingListOfAbilityInstances.Add( new AbilityInstance( ArchAbility.LangHighGerman,  75, "(dialect)"     ) );
-            bindingListOfAbilityInstances.Add( new AbilityInstance( ArchAbility.LangLatin,  50, "Hermetic usage") );
-            bindingListOfAbilityInstances.Add( new AbilityInstance( ArchAbility.ArtesLiberales,  15, "Astronomy"     ) );
-            bindingListOfAbilityInstances.Add( new AbilityInstance( ArchAbility.HermeticMagicTheory,  5, "Spell research") );
-            bindingListOfAbilityInstances.Add( new AbilityInstance( ArchAbility.Concentration,  140, "Duration",      AFF, PUI, 2 ) );
+            bindingListOfAbilityInstances.Add( new AbilityInstance( ArchAbility.LangHighGerman,  AbilityInstance.createID(), 75, "(dialect)"     ) );
+            bindingListOfAbilityInstances.Add( new AbilityInstance( ArchAbility.LangLatin,  AbilityInstance.createID(), 50, "Hermetic usage") );
+            bindingListOfAbilityInstances.Add( new AbilityInstance( ArchAbility.ArtesLiberales,  AbilityInstance.createID(), 15, "Astronomy"     ) );
+            bindingListOfAbilityInstances.Add( new AbilityInstance( ArchAbility.HermeticMagicTheory,  AbilityInstance.createID(), 5, "Spell research") );
+            bindingListOfAbilityInstances.Add( new AbilityInstance( ArchAbility.Concentration,  AbilityInstance.createID(), 140, "Duration",      AFF, PUI, 2 ) );
 
             this.GridForAbilities.DataSource = bindingListOfAbilityInstances;
 

--- a/WizardMakerTestbed/Models/AbilityModels.cs
+++ b/WizardMakerTestbed/Models/AbilityModels.cs
@@ -393,7 +393,8 @@ namespace WizardMakerPrototype.Models
         [Browsable(false)]
         public int  PuissantBonus  { get; private set; } = 2;
 
-        public string journalID { get; private set; }
+        // Assumption:  Each of these journal entries are ones that spend XP and that no single XP-spending journal entry will involve more than this ability instance (ie, only one ability instance).
+        public List<string> journalIDs { get; private set; }
 
         public decimal determineXpCost(ArchAbility archAbility)
         {
@@ -415,7 +416,7 @@ namespace WizardMakerPrototype.Models
             this.HasAffinity   = hasAffinity;
             this.HasPuissance  = hasPuissance;
             this.PuissantBonus = puissantBonus;
-            this.journalID = journalID;
+            this.journalIDs = new List<string>() { journalID};
         }
 
         public override string ToString ()
@@ -423,6 +424,11 @@ namespace WizardMakerPrototype.Models
             string str = string.Format("{0} '{1}' XP={2} / S={3} ({4}) A={5}, P={6}",
                 this.TypeAbbrev, this.Name, this.XP, this.Score, this.Specialty, HasAffinity, HasPuissance);
             return str;
+        }
+
+        public void addJournalID(string journalID)
+        {
+            this.journalIDs.Add(journalID);
         }
 
         // This is used mostly for testing.  In cases where we do not have an ID from the Jounral Entry.

--- a/WizardMakerTestbed/Models/AbilityModels.cs
+++ b/WizardMakerTestbed/Models/AbilityModels.cs
@@ -393,9 +393,7 @@ namespace WizardMakerPrototype.Models
         [Browsable(false)]
         public int  PuissantBonus  { get; private set; } = 2;
 
-        // Used to tie this abillity to the journal entry associated with it.
-        // TODO: This is a bit complicated, could we simplify the design?  This is necessary to support deletion from a GUI.  
-        public string id;
+        public string journalID { get; private set; }
 
         public decimal determineXpCost(ArchAbility archAbility)
         {
@@ -406,7 +404,7 @@ namespace WizardMakerPrototype.Models
         // Something more will be needed to represent how Languages
         // get a Puissant-like bonus from a related Language with a higher Score...
 
-        public AbilityInstance ( ArchAbility ability, int xp = 0, string specialty = "", 
+        public AbilityInstance ( ArchAbility ability, string journalID, int xp = 0, string specialty = "", 
             bool hasAffinity = false, bool hasPuissance = false, int puissantBonus = 2)
         {
             decimal xpCost = determineXpCost(ability);
@@ -417,7 +415,7 @@ namespace WizardMakerPrototype.Models
             this.HasAffinity   = hasAffinity;
             this.HasPuissance  = hasPuissance;
             this.PuissantBonus = puissantBonus;
-            this.id = createID();
+            this.journalID = journalID;
         }
 
         public override string ToString ()
@@ -427,6 +425,7 @@ namespace WizardMakerPrototype.Models
             return str;
         }
 
+        // This is used mostly for testing.  In cases where we do not have an ID from the Jounral Entry.
         public static string createID()
         {
             Guid myuuid = Guid.NewGuid();

--- a/WizardMakerTestbed/Models/AbilityXPManager.cs
+++ b/WizardMakerTestbed/Models/AbilityXPManager.cs
@@ -34,13 +34,13 @@ namespace WizardMakerPrototype.Models
             return new ValidationResult();
         }
 
-        public static AbilityInstance createNewAbilityInstance(string ability, int xp, string specialty)
+        public static AbilityInstance createNewAbilityInstance(string ability, int xp, string specialty, string journalID)
         {
             // Create the ability instance
             ArchAbility archAbility = ArchAbility.lookupCommonAbilities(ability);
             validateSpendXPOnAbility(archAbility, xp);
 
-            return new AbilityInstance(archAbility, xp, specialty);
+            return new AbilityInstance(archAbility, journalID, xp, specialty);
         }
 
         public static void debitXPPoolsForAbility(AbilityInstance a, int xp, SortedSet<XPPool> XPPoolList)

--- a/WizardMakerTestbed/Models/Character.cs
+++ b/WizardMakerTestbed/Models/Character.cs
@@ -40,6 +40,16 @@ namespace WizardMakerPrototype.Models
             this.startingAge = startingAge;
             this.XPPoolList = new SortedSet<XPPool>(new XPPoolComparer());
         }
+        
+        public void EndCharacterCreation()
+        {
+            journalableManager.setCharacterGenerationMode(false);
+        }
+
+        public bool IsInitialCharacterFinished()
+        {
+            return !journalableManager.isInCharacterGenerationMode();
+        }
 
         public void addJournalable(Journalable journalable) { journalableManager.addJournalable(journalable); }
         public void removeJournalable(string text) { journalableManager.removeJournalEntry(text); }

--- a/WizardMakerTestbed/Models/Character.cs
+++ b/WizardMakerTestbed/Models/Character.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using WizardMakerPrototype.Models.CharacterPersist;
 using WizardMakerTestbed.Models;
 
 namespace WizardMakerPrototype.Models
@@ -16,13 +17,14 @@ namespace WizardMakerPrototype.Models
         public List<AbilityInstance> abilities { get; set; }
         public SortedSet<XPPool> XPPoolList { get; }
 
-
         public int startingAge { get; set; }
 
         private IJournalableManager journalableManager { get; set; }
 
         private SortedSet<Journalable> journalEntries { get { return journalableManager.getJournalables(); } }
 
+        public Character(RawCharacter rc) : this(rc.Name, rc.Description, new List<AbilityInstance>(), rc.journalEntries, rc.startingAge) { }
+            
         public Character(string name, string description, int startingAge) : this(name, description, new List<AbilityInstance>(), new List<Journalable>(), startingAge) { }
         
 

--- a/WizardMakerTestbed/Models/CharacterData.cs
+++ b/WizardMakerTestbed/Models/CharacterData.cs
@@ -55,9 +55,9 @@ namespace WizardMakerPrototype.Models
         public int Score { get; }
         public string Specialty { get; }
 
-        public string Id { get; }
+        public List<string> Id { get; private set; }
 
-        public AbilityInstanceData(string category, string type, string typeAbbrev, string name, int xP, int score, string specialty, string id)
+        public AbilityInstanceData(string category, string type, string typeAbbrev, string name, int xP, int score, string specialty, List<string> id)
         {
             Category = category;
             Type = type;

--- a/WizardMakerTestbed/Models/CharacterManager.cs
+++ b/WizardMakerTestbed/Models/CharacterManager.cs
@@ -1,12 +1,15 @@
 ﻿using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using WizardMakerTestbed.Models;
+using WizardMakerPrototype.Models.CharacterPersist;
 
 [assembly: InternalsVisibleTo("WizardMakerTests")]
 [assembly: InternalsVisibleTo("WizardMakerTests.Models")]
+[assembly: InternalsVisibleTo("WizardMakerTests.Models.Tests")]
 namespace WizardMakerPrototype.Models
 {
     /**
@@ -89,5 +92,30 @@ namespace WizardMakerPrototype.Models
         }
 
         public int getJournalSize() { return Character.GetJournal().Count; }
+
+        // TODO: A lot more error checking needs to take place here
+        // TODO: How would this work for API front end? 
+        // Note: This will overwrite any file
+        public static void WriteToFile(Character c, string absoluteFilename)
+        {
+            FileStream fs = new FileStream(absoluteFilename, FileMode.Create, FileAccess.Write);
+            StreamWriter sw = new StreamWriter(fs);
+            RawCharacter rc = new RawCharacter(c);
+            sw.Write(rc.serializeJson());
+            sw.Flush();
+            sw.Close();
+            fs.Close();
+        }
+
+        public static Character ReadFromFile(string absoluteFilename)
+        {
+            FileStream fs = new FileStream(absoluteFilename, FileMode.Open, FileAccess.Read);
+            StreamReader sw = new StreamReader(fs);
+            RawCharacter rc = RawCharacter.deserializeJson(sw.ReadToEnd());
+            sw.Close();
+            fs.Close();
+
+            return new Character(rc);
+        }
     }
 }

--- a/WizardMakerTestbed/Models/CharacterManager.cs
+++ b/WizardMakerTestbed/Models/CharacterManager.cs
@@ -63,7 +63,7 @@ namespace WizardMakerPrototype.Models
             CharacterRenderer.renderAllJournalEntries(Character);
         }
 
-        public void deleteAbilityInstance(string id)
+        public void deleteJournalEntry(string id)
         {
             Character.removeJournalable(id);
 

--- a/WizardMakerTestbed/Models/CharacterManager.cs
+++ b/WizardMakerTestbed/Models/CharacterManager.cs
@@ -52,8 +52,9 @@ namespace WizardMakerPrototype.Models
          */
         public void updateAbilityDuringCreation(string ability, int absoluteXp, string specialty)
         {
+            //TODO: Fix the ordering because the SeasonYear must always be later than the NewCharacterJournalInit
             XpAbilitySpendJournalEntry xpAbilitySpendJournalEntry = new XpAbilitySpendJournalEntry(ABILITY_CREATION_NAME_PREFIX + ability,
-                new SeasonYear(1219, Season.SPRING), ability, absoluteXp, specialty);
+                new SeasonYear(1219, Season.SUMMER), ability, absoluteXp, specialty);
 
             Character.addJournalable(xpAbilitySpendJournalEntry);
             CharacterRenderer.renderAllJournalEntries(Character);

--- a/WizardMakerTestbed/Models/CharacterManager.cs
+++ b/WizardMakerTestbed/Models/CharacterManager.cs
@@ -63,7 +63,7 @@ namespace WizardMakerPrototype.Models
             CharacterRenderer.renderAllJournalEntries(Character);
         }
 
-        public void deleteJournalEntry(string id)
+        public void DeleteJournalEntry(string id)
         {
             Character.removeJournalable(id);
 

--- a/WizardMakerTestbed/Models/CharacterPersist/RawCharacter.cs
+++ b/WizardMakerTestbed/Models/CharacterPersist/RawCharacter.cs
@@ -1,0 +1,58 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace WizardMakerPrototype.Models.CharacterPersist
+{
+    // This character is just basic metadata and journal entries and must always be serializable.
+    //  This class if for loading and saving of characters.
+    //  TODO: Do we need this class if we have CharacterData?  Could we drop this class and just make a custom serialization/deserialization scheme in Character?
+    //  TODO: Make this class a private class to Character?
+    public class RawCharacter
+    {
+        public string Name { get; set; }
+        public string Description { get; set; }
+
+        public int startingAge { get; set; }
+
+        public List<Journalable> journalEntries { get; }
+        public string serializeJson()
+        {
+            var settings = new JsonSerializerSettings();
+            settings.TypeNameHandling = TypeNameHandling.All;
+
+            return JsonConvert.SerializeObject(this, Formatting.Indented, settings);
+        }
+
+        public static RawCharacter deserializeJson(string json)
+        {
+            JsonSerializerSettings settings = new JsonSerializerSettings
+            {
+                TypeNameHandling = TypeNameHandling.All,
+                MaxDepth = 128
+            };
+
+            return (RawCharacter) JsonConvert.DeserializeObject(json, settings);
+        }
+
+        [JsonConstructor]
+        public RawCharacter(string name, string description, int startingAge, List<Journalable> journalEntries)
+        {
+            Name = name;
+            Description = description;
+            this.startingAge = startingAge;
+            this.journalEntries = journalEntries;
+        }
+
+        public RawCharacter(Character c)
+        {
+            Name = c.Name;
+            Description = c.Description;
+            startingAge = c.startingAge;
+            journalEntries = c.GetJournal().ToList();
+        }
+    }
+}

--- a/WizardMakerTestbed/Models/CharacterRenderer.cs
+++ b/WizardMakerTestbed/Models/CharacterRenderer.cs
@@ -83,7 +83,7 @@ namespace WizardMakerPrototype.Models
             // Note that for the front end the ID of the ability is also the name.  This may need to be cahnged in the future.
             return new AbilityInstanceData(abilityInstance.Category,
                 abilityInstance.Type, abilityInstance.TypeAbbrev.ToString(), abilityInstance.Name, abilityInstance.XP, abilityInstance.Score,
-                abilityInstance.Specialty, abilityInstance.journalID);
+                abilityInstance.Specialty, abilityInstance.journalIDs);
         }
 
         public static CharacterData renderCharacterAsCharacterData(Character character)

--- a/WizardMakerTestbed/Models/CharacterRenderer.cs
+++ b/WizardMakerTestbed/Models/CharacterRenderer.cs
@@ -33,13 +33,13 @@ namespace WizardMakerPrototype.Models
          * Ignores the specialty if the ability already exists.  Note this assumes only one specialty per ability.
          * XP is always absolute XP, unless it is flagged as incremental.  Then it will be added.
          */
-        public static void addAbility(Character character, string ability, int xp, string specialty, bool isIncrementalXP)
+        public static void addAbility(Character character, string ability, int xp, string specialty, bool isIncrementalXP, string journalID)
         {
             if (!doesCharacterHaveAbility(character, ability))
             {
 
                 // add the ability to the character
-                character.abilities.Add(AbilityXPManager.createNewAbilityInstance(ability, xp, specialty));
+                character.abilities.Add(AbilityXPManager.createNewAbilityInstance(ability, xp, specialty, journalID));
             }
             else
             {
@@ -83,7 +83,7 @@ namespace WizardMakerPrototype.Models
             // Note that for the front end the ID of the ability is also the name.  This may need to be cahnged in the future.
             return new AbilityInstanceData(abilityInstance.Category,
                 abilityInstance.Type, abilityInstance.TypeAbbrev.ToString(), abilityInstance.Name, abilityInstance.XP, abilityInstance.Score,
-                abilityInstance.Specialty, abilityInstance.id);
+                abilityInstance.Specialty, abilityInstance.journalID);
         }
 
         public static CharacterData renderCharacterAsCharacterData(Character character)

--- a/WizardMakerTestbed/Models/CharacterRenderer.cs
+++ b/WizardMakerTestbed/Models/CharacterRenderer.cs
@@ -29,13 +29,11 @@ namespace WizardMakerPrototype.Models
             }
         }
 
-        //TODO: Need to create a way to modify/remove journal entries
-        //  This will include rerendering the character in its entirety
         /** 
          * Ignores the specialty if the ability already exists.  Note this assumes only one specialty per ability.
-         * XP is always absolute XP.  
+         * XP is always absolute XP, unless it is flagged as incremental.  Then it will be added.
          */
-        public static void addAbility(Character character, string ability, int xp, string specialty)
+        public static void addAbility(Character character, string ability, int xp, string specialty, bool isIncrementalXP)
         {
             if (!doesCharacterHaveAbility(character, ability))
             {
@@ -45,8 +43,8 @@ namespace WizardMakerPrototype.Models
             }
             else
             {
-                retrieveAbilityInstance(character, ability).XP = xp;
-
+                if (isIncrementalXP) { retrieveAbilityInstance(character, ability).XP += xp; }
+                else { retrieveAbilityInstance(character, ability).XP = xp; }
             }
 
             AbilityXPManager.debitXPPoolsForAbility(retrieveAbilityInstance(character, ability), xp, character.XPPoolList);

--- a/WizardMakerTestbed/Models/Journal/IJournalableManager.cs
+++ b/WizardMakerTestbed/Models/Journal/IJournalableManager.cs
@@ -29,7 +29,13 @@ namespace WizardMakerPrototype.Models
             {
                 if (x.getDate().season == y.getDate().season)
                 {
-                    return new CaseInsensitiveComparer().Compare(x.getText(), y.getText());
+                    if (x.getId() == y.getId())
+                    {
+                        return new CaseInsensitiveComparer().Compare(x.getText(), y.getText());
+                    } else
+                    {
+                        return new CaseInsensitiveComparer().Compare(x.getId(), y.getId());
+                    }
                 } else
                 {
                     return x.getDate().season.CompareTo(y.getDate().season);

--- a/WizardMakerTestbed/Models/Journal/IJournalableManager.cs
+++ b/WizardMakerTestbed/Models/Journal/IJournalableManager.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 
 namespace WizardMakerPrototype.Models
 {
+    // TODO: We can probably get rid of this interface.  It adds a layer of abstraction that we likely do not need.
     internal interface IJournalableManager
     {
         /**

--- a/WizardMakerTestbed/Models/Journal/XpAbilitySpendJournalEntry.cs
+++ b/WizardMakerTestbed/Models/Journal/XpAbilitySpendJournalEntry.cs
@@ -35,7 +35,7 @@ namespace WizardMakerPrototype.Models
 
         public override void Execute(Character character)
         {
-            CharacterRenderer.addAbility(character, ability, xp, specialty, character.IsInitialCharacterFinished());
+            CharacterRenderer.addAbility(character, ability, xp, specialty);
         }
 
         public override void Undo()

--- a/WizardMakerTestbed/Models/Journal/XpAbilitySpendJournalEntry.cs
+++ b/WizardMakerTestbed/Models/Journal/XpAbilitySpendJournalEntry.cs
@@ -35,7 +35,7 @@ namespace WizardMakerPrototype.Models
 
         public override void Execute(Character character)
         {
-            CharacterRenderer.addAbility(character, ability, xp, specialty, character.IsInitialCharacterFinished());
+            CharacterRenderer.addAbility(character, ability, xp, specialty, character.IsInitialCharacterFinished(), this.getId());
         }
 
         public override void Undo()

--- a/WizardMakerTestbed/Models/Journal/XpAbilitySpendJournalEntry.cs
+++ b/WizardMakerTestbed/Models/Journal/XpAbilitySpendJournalEntry.cs
@@ -35,7 +35,7 @@ namespace WizardMakerPrototype.Models
 
         public override void Execute(Character character)
         {
-            CharacterRenderer.addAbility(character, ability, xp, specialty);
+            CharacterRenderer.addAbility(character, ability, xp, specialty, character.IsInitialCharacterFinished());
         }
 
         public override void Undo()

--- a/WizardMakerTestbed/Models/Journal/XpAbilitySpendJournalEntry.cs
+++ b/WizardMakerTestbed/Models/Journal/XpAbilitySpendJournalEntry.cs
@@ -5,6 +5,8 @@ namespace WizardMakerPrototype.Models
     //TODO: If a user edits an XP Value *during character creation*,
     //   should we optimize the journal entries by removing the original (or combining into one)?
     // That would break an undo command....
+    // Dev note:  Deletion of abilities are assumed to link to multiple journal entries.  No XpAbilitySpendJournalEntry can grant XP to more than one ability.  If this
+    //  capability is needed, then a more complex mechanism will be needed for implementation.
     public class XpAbilitySpendJournalEntry : Journalable
     {
 

--- a/WizardMakerTestbed/Tester.Designer.cs
+++ b/WizardMakerTestbed/Tester.Designer.cs
@@ -110,7 +110,7 @@
             // XPPoolsJson
             // 
             this.XPPoolsJson.AutoSize = true;
-            this.XPPoolsJson.Location = new System.Drawing.Point(682, 154);
+            this.XPPoolsJson.Location = new System.Drawing.Point(676, 9);
             this.XPPoolsJson.Name = "XPPoolsJson";
             this.XPPoolsJson.Size = new System.Drawing.Size(47, 13);
             this.XPPoolsJson.TabIndex = 7;

--- a/WizardMakerTestbed/Tester.cs
+++ b/WizardMakerTestbed/Tester.cs
@@ -85,30 +85,33 @@ namespace WizardMakerPrototype
             // Handle a deletion
             if (dataGridView1.Columns[colIndex].HeaderText == "Delete")
             {
-                
+
                 string deletedAbility = dataGridView1.Rows[rowIndex].Cells[0].Value.ToString();
-                string abilityId = retrieveAbilityIdFromAbilityName(deletedAbility);
-                if (abilityId == null)
+                List<string> abilityIds = retrieveAbilityIdsFromAbilityName(deletedAbility);
+                if (abilityIds == null)
                 {
                     throw new ShouldNotBeAbleToGetHereException("Could not find ID for " + deletedAbility);
                 }
-                characterManager.deleteAbilityInstance(abilityId);
+                foreach (string abilityId in abilityIds) { 
+                    characterManager.deleteJournalEntry(abilityId);
+                }
                 updateCharacterDisplay();
             }
         }
 
-        private string retrieveAbilityIdFromAbilityName(string name)
+        private List<string> retrieveAbilityIdsFromAbilityName(string name)
         {
             CharacterData c = characterManager.renderCharacterAsCharacterData();
+            List<string> result = new List<string>();
             foreach (var a in c.Abilities)
             {
                 if (a.Name == name)
                 {
-                    return a.Id;
+                    result.AddRange(a.Id);
                 }
             }
 
-            return null;
+            return result;
         }
 
         private void dataGridView1_CellEndEdit(object sender, DataGridViewCellEventArgs e)

--- a/WizardMakerTestbed/WizardMakerTestbed.csproj
+++ b/WizardMakerTestbed/WizardMakerTestbed.csproj
@@ -108,6 +108,7 @@
     <Compile Include="Models\Journal\IJournalableManager.cs" />
     <Compile Include="Models\InvalidCharacterInitializationException.cs" />
     <Compile Include="Models\Journal\Journalable.cs" />
+    <Compile Include="Models\CharacterPersist\RawCharacter.cs" />
     <Compile Include="Models\ShouldNotBeAbleToGetHereException.cs" />
     <Compile Include="Models\Journal\SingleJournalEntry.cs" />
     <Compile Include="Models\Journal\XpAbilitySpendJournalEntry.cs" />

--- a/WizardMakerTests/Models/CharacterManagerTests.cs
+++ b/WizardMakerTests/Models/CharacterManagerTests.cs
@@ -34,10 +34,13 @@ namespace WizardMakerPrototype.Models.Tests
             CharacterData cd = cm.renderCharacterAsCharacterData();
             Assert.IsNotNull(cd);
             Assert.AreEqual(2, cd.Abilities.Count);
-            Assert.AreEqual(n, cd.Abilities[0].Name);
-            Assert.AreEqual(xp2, cd.Abilities[0].XP);
-            Assert.AreEqual(s, cd.Abilities[0].Specialty);
-            Assert.AreEqual(expectedScore, cd.Abilities[0].Score);
+
+            AbilityInstanceData testedAbility = cd.Abilities.Where(a => a.Name == n).First();
+
+            Assert.IsTrue(cd.Abilities.Select(a => a.Name.Equals(n)).ToList().Count > 0);
+            Assert.AreEqual(xp2, testedAbility.XP);
+            Assert.AreEqual(s, testedAbility.Specialty);
+            Assert.AreEqual(expectedScore, testedAbility.Score);
             
             // We should only have one Bow ability listed.
             Assert.AreEqual(1, cd.Abilities.Count(a => a.Name == n));

--- a/WizardMakerTests/Models/CharacterRendererTests.cs
+++ b/WizardMakerTests/Models/CharacterRendererTests.cs
@@ -19,7 +19,7 @@ namespace WizardMakerTests.Models
         {
             Character c = new ("Foo", "Looks like a foo", 25);
             c.XPPoolList.Add(new BasicXPPool("dummy", "dummy XP Pool", 500));
-            CharacterRenderer.addAbility(c, n, xp, s);
+            CharacterRenderer.addAbility(c, n, xp, s, c.IsInitialCharacterFinished());
             CharacterData characterData = CharacterRenderer.renderCharacterAsCharacterData(c);
 
             // Language abillity is added automatically.
@@ -30,5 +30,59 @@ namespace WizardMakerTests.Models
             Assert.AreEqual(s, characterData.Abilities[0].Specialty);
             Assert.AreEqual(expectedScore, characterData.Abilities[0].Score);
         }
+
+        [TestMethod]
+        public void AbilitiesRenderingTimingTest()
+        {
+            Random rnd = new Random(1212);
+            const int STARTING_AGE = 25;
+            const int XP_PER_SEASON = 20;
+            // Look at the timing for rendering an entire character.
+            Character c = new("Foo", "Looks like a foo", STARTING_AGE);
+
+            NewCharacterInitJournalEntry initEntry = new NewCharacterInitJournalEntry(STARTING_AGE, ArchAbility.LangEnglish, XP_PER_SEASON);
+            c.addJournalable(initEntry);
+
+            Dictionary<string, int> xpSpentMap = new Dictionary<string, int>();
+
+            const int ENTRIES_PER_ABILITY = 50;
+            const int XP_PER_ENTRY = 5;
+
+            for (int i = 0; i < ENTRIES_PER_ABILITY; i++)
+            {
+
+                foreach (ArchAbility archAbility in ArchAbility.AllCommonAbilities)
+                {
+                    int jitter = rnd.Next(0, 5);
+
+                    XpAbilitySpendJournalEntry xpAbilitySpend = new XpAbilitySpendJournalEntry("Spend on " + archAbility.Name, new SeasonYear(1220, Season.SPRING),
+                        archAbility.Name, XP_PER_ENTRY + jitter, "Dummy specialty");
+                    c.addJournalable(xpAbilitySpend);
+                    xpSpentMap.Add(archAbility.Name, xpSpentMap.GetValueOrDefault(archAbility.Name, 0) + XP_PER_ENTRY + jitter);
+                }
+                if (i == 0)
+                {
+                    c.EndCharacterCreation();
+                }
+            }
+
+            DateTime timeStart = DateTime.Now;
+            CharacterRenderer.renderAllJournalEntries(c);
+            CharacterData cd = CharacterRenderer.renderCharacterAsCharacterData(c);
+            
+            DateTime timeEnd = DateTime.Now;
+            long elapsedTicks = timeEnd.Ticks - timeStart.Ticks;
+            TimeSpan elapsedSpan = new TimeSpan(elapsedTicks);
+            Console.WriteLine("   {0:N0} nanoseconds", elapsedTicks * 100);
+            Console.WriteLine("   {0:N0}", cd.Abilities.Count);
+
+            Assert.AreEqual(ArchAbility.AllCommonAbilities.Count, cd.Abilities.Count);
+            for (int i = 0; i < cd.Abilities.Count; i++)
+            {
+                Assert.AreEqual(xpSpentMap.GetValueOrDefault(cd.Abilities[i].Name, -1), cd.Abilities[i].XP);
+            }
+        }
     }
+
+   
 }

--- a/WizardMakerTests/Models/CharacterRendererTests.cs
+++ b/WizardMakerTests/Models/CharacterRendererTests.cs
@@ -19,7 +19,7 @@ namespace WizardMakerTests.Models
         {
             Character c = new ("Foo", "Looks like a foo", 25);
             c.XPPoolList.Add(new BasicXPPool("dummy", "dummy XP Pool", 500));
-            CharacterRenderer.addAbility(c, n, xp, s, c.IsInitialCharacterFinished());
+            CharacterRenderer.addAbility(c, n, xp, s, c.IsInitialCharacterFinished(), "dummyID");
             CharacterData characterData = CharacterRenderer.renderCharacterAsCharacterData(c);
 
             // Language abillity is added automatically.

--- a/WizardMakerTests/Models/CharacterRendererTests.cs
+++ b/WizardMakerTests/Models/CharacterRendererTests.cs
@@ -37,8 +37,9 @@ namespace WizardMakerTests.Models
             Random rnd = new Random(1212);
             const int STARTING_AGE = 25;
             const int XP_PER_SEASON = 20;
+
             // Look at the timing for rendering an entire character.
-            Character c = new("Foo", "Looks like a foo", STARTING_AGE);
+            Character c = new("Foo", "Best mage ever.  They really know a lot.", STARTING_AGE);
 
             NewCharacterInitJournalEntry initEntry = new NewCharacterInitJournalEntry(STARTING_AGE, ArchAbility.LangEnglish, XP_PER_SEASON);
             c.addJournalable(initEntry);
@@ -58,7 +59,16 @@ namespace WizardMakerTests.Models
                     XpAbilitySpendJournalEntry xpAbilitySpend = new XpAbilitySpendJournalEntry("Spend on " + archAbility.Name, new SeasonYear(1220, Season.SPRING),
                         archAbility.Name, XP_PER_ENTRY + jitter, "Dummy specialty");
                     c.addJournalable(xpAbilitySpend);
-                    xpSpentMap.Add(archAbility.Name, xpSpentMap.GetValueOrDefault(archAbility.Name, 0) + XP_PER_ENTRY + jitter);
+
+                    // Track the XP spending as we go.
+                    if (xpSpentMap.ContainsKey(archAbility.Name))
+                    {
+                        xpSpentMap[archAbility.Name] = xpSpentMap[archAbility.Name] + XP_PER_ENTRY + jitter;
+                    }
+                    else
+                    {
+                        xpSpentMap.Add(archAbility.Name, XP_PER_ENTRY + jitter);
+                    }
                 }
                 if (i == 0)
                 {
@@ -66,21 +76,33 @@ namespace WizardMakerTests.Models
                 }
             }
 
+            // Start a timer
             DateTime timeStart = DateTime.Now;
+
+            // Render the character as a CharacterData
             CharacterRenderer.renderAllJournalEntries(c);
             CharacterData cd = CharacterRenderer.renderCharacterAsCharacterData(c);
-            
+
+            // Serialize the CharacterData
+            string foo = CharacterRenderer.serializeCharacterData(cd);
+
+            // Stop the timer
             DateTime timeEnd = DateTime.Now;
+
+            // Output some useful information to the console.
             long elapsedTicks = timeEnd.Ticks - timeStart.Ticks;
             TimeSpan elapsedSpan = new TimeSpan(elapsedTicks);
             Console.WriteLine("   {0:N0} nanoseconds", elapsedTicks * 100);
             Console.WriteLine("   {0:N0}", cd.Abilities.Count);
 
+            // Do some basic testing that the XP spends are as expected.
             Assert.AreEqual(ArchAbility.AllCommonAbilities.Count, cd.Abilities.Count);
             for (int i = 0; i < cd.Abilities.Count; i++)
             {
                 Assert.AreEqual(xpSpentMap.GetValueOrDefault(cd.Abilities[i].Name, -1), cd.Abilities[i].XP);
             }
+
+            Console.WriteLine(foo);
         }
     }
 

--- a/WizardMakerTests/Models/Journal/NewCharacterInitJournalEntryTest.cs
+++ b/WizardMakerTests/Models/Journal/NewCharacterInitJournalEntryTest.cs
@@ -65,8 +65,5 @@ namespace WizardMakerTests.Models.Journal
             //  this should not happen due to usage of GetType
             Assert.IsTrue(entry.IsSameSpecs(deserialized));
         }
-
-
-
     }
 }

--- a/WizardMakerTests/Models/Journal/NewCharacterInitJournalEntryTest.cs
+++ b/WizardMakerTests/Models/Journal/NewCharacterInitJournalEntryTest.cs
@@ -65,5 +65,8 @@ namespace WizardMakerTests.Models.Journal
             //  this should not happen due to usage of GetType
             Assert.IsTrue(entry.IsSameSpecs(deserialized));
         }
+
+
+
     }
 }

--- a/WizardMakerTests/Models/Journal/NewCharacterInitJournalEntryTest.cs
+++ b/WizardMakerTests/Models/Journal/NewCharacterInitJournalEntryTest.cs
@@ -57,6 +57,7 @@ namespace WizardMakerTests.Models.Journal
             string tmp = entry.SerializeJson();
             Journalable deserialized = Journalable.DeserializeJson(tmp);
 
+
             Assert.IsNotNull(deserialized);
             Assert.IsNotNull(tmp);
 
@@ -64,5 +65,8 @@ namespace WizardMakerTests.Models.Journal
             //  this should not happen due to usage of GetType
             Assert.IsTrue(entry.IsSameSpecs(deserialized));
         }
+
+
+
     }
 }

--- a/WizardMakerTests/Models/Journal/XpAbilitySpendJournalEntryTests.cs
+++ b/WizardMakerTests/Models/Journal/XpAbilitySpendJournalEntryTests.cs
@@ -115,5 +115,7 @@ namespace WizardMakerPrototype.Models.Tests
             //  this should not happen due to usage of GetType
             Assert.IsTrue(entry.IsSameSpecs(deserialized));
         }
+
+
     }
 }

--- a/WizardMakerTests/Models/Journal/XpAbilitySpendJournalEntryTests.cs
+++ b/WizardMakerTests/Models/Journal/XpAbilitySpendJournalEntryTests.cs
@@ -115,7 +115,5 @@ namespace WizardMakerPrototype.Models.Tests
             //  this should not happen due to usage of GetType
             Assert.IsTrue(entry.IsSameSpecs(deserialized));
         }
-
-
     }
 }

--- a/WizardMakerTests/XPPoolTest.cs
+++ b/WizardMakerTests/XPPoolTest.cs
@@ -106,9 +106,9 @@ namespace WizardMakerTests
                 new AllowOverdrawnXpPool()
             };
 
-            AbilityInstance english = new AbilityInstance(ArchAbility.LangEnglish, 75);
+            AbilityInstance english = new AbilityInstance(ArchAbility.LangEnglish, "testID1", 75);
             
-            AbilityInstance charm = new AbilityInstance(ArchAbility.Charm, 75);
+            AbilityInstance charm = new AbilityInstance(ArchAbility.Charm, "testID2", 75);
 
             AbilityXPManager.debitXPPoolsForAbility(english, pools);
             AbilityXPManager.debitXPPoolsForAbility(charm, pools);


### PR DESCRIPTION
- Renamed some namespaces
- Serializing journal entries
- Made Journalable an abstract class rather than interface.  This helped with serialization.
- Made abilities have multiple linked IDs.  This is for multiple journal entries.
- Very basic round-trip save/load of characters implemented.  Only works with a filesystem and no error checking happens.
- Added some more packages to better separate codebase (eg, Journal package)
- Added test that looks at timing to render thousands of ability XP spend journal entries.