### PR TITLE
Ability Virtues Part 1

### DIFF
--- a/WizardMakerTestbed/Models/AbilityXPManager.cs
+++ b/WizardMakerTestbed/Models/AbilityXPManager.cs
@@ -34,13 +34,13 @@ namespace WizardMakerPrototype.Models
             return new ValidationResult();
         }
 
-        public static AbilityInstance createNewAbilityInstance(string ability, int xp, string specialty, string journalID)
+        public static AbilityInstance createNewAbilityInstance(string ability, int xp, string specialty, string journalID, bool isPuissant)
         {
             // Create the ability instance
             ArchAbility archAbility = ArchAbility.lookupCommonAbilities(ability);
             validateSpendXPOnAbility(archAbility, xp);
 
-            return new AbilityInstance(archAbility, journalID, xp, specialty);
+            return new AbilityInstance(archAbility, journalID, xp, specialty, hasPuissance:isPuissant);
         }
 
         public static void debitXPPoolsForAbility(AbilityInstance a, int xp, SortedSet<XPPool> XPPoolList)

--- a/WizardMakerTestbed/Models/Character.cs
+++ b/WizardMakerTestbed/Models/Character.cs
@@ -18,7 +18,7 @@ namespace WizardMakerPrototype.Models
         public List<AbilityInstance> abilities { get; set; }
         public SortedSet<XPPool> XPPoolList { get; }
 
-        public int XpPerSeasonForInitialCreation { get; set; } = 15;
+        public int XpPerYear { get; set; } = 15;
 
         public List<VirtueInstance> virtues { get; private set; }
 

--- a/WizardMakerTestbed/Models/Character.cs
+++ b/WizardMakerTestbed/Models/Character.cs
@@ -45,6 +45,7 @@ namespace WizardMakerPrototype.Models
             }
             this.startingAge = startingAge;
             this.XPPoolList = new SortedSet<XPPool>(new XPPoolComparer());
+            this.virtues = new List<VirtueInstance>();
         }
         
         public void EndCharacterCreation()

--- a/WizardMakerTestbed/Models/Character.cs
+++ b/WizardMakerTestbed/Models/Character.cs
@@ -16,6 +16,9 @@ namespace WizardMakerPrototype.Models
         public string Description { get; set; }
 
         public List<AbilityInstance> abilities { get; set; }
+
+        public List<string> puissantAbilities { get; set; } = new List<string>();
+        public List<string> affinityAbilities { get; set; } = new List<string>();
         public SortedSet<XPPool> XPPoolList { get; }
 
         public int XpPerYear { get; set; } = 15;

--- a/WizardMakerTestbed/Models/Character.cs
+++ b/WizardMakerTestbed/Models/Character.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using WizardMakerPrototype.Models.CharacterPersist;
+using WizardMakerPrototype.Models.Virtues;
 using WizardMakerTestbed.Models;
 
 namespace WizardMakerPrototype.Models
@@ -16,6 +17,10 @@ namespace WizardMakerPrototype.Models
 
         public List<AbilityInstance> abilities { get; set; }
         public SortedSet<XPPool> XPPoolList { get; }
+
+        public int XpPerSeasonForInitialCreation { get; set; } = 15;
+
+        public List<VirtueInstance> virtues { get; private set; }
 
         public int startingAge { get; set; }
 

--- a/WizardMakerTestbed/Models/CharacterManager.cs
+++ b/WizardMakerTestbed/Models/CharacterManager.cs
@@ -21,6 +21,7 @@ namespace WizardMakerPrototype.Models
         private Character Character;
 
         public const string ABILITY_CREATION_NAME_PREFIX = "Initial: ";
+        public const int SAGA_START_YEAR = 1220;
 
         public CharacterManager(int startingAge)
         {
@@ -30,7 +31,7 @@ namespace WizardMakerPrototype.Models
             this.Character = new Character("New Character", "", startingAge);
             
             //TODO: Re-assess whether initializing a journal entry with "this" has a smell.
-            this.Character.addJournalable(new NewCharacterInitJournalEntry(startingAge, childhoodLanguage, Character.XpPerSeasonForInitialCreation));
+            this.Character.addJournalable(new NewCharacterInitJournalEntry(startingAge, childhoodLanguage, SAGA_START_YEAR));
 
             // TODO: Need a layer that will judge what abilities a character is even allowed to choose at any time (given that virtues and flaws can change this access).
             updateAbilityDuringCreation(childhoodLanguage.Name, NewCharacterInitJournalEntry.CHILDHOOD_LANGUAGE_XP, "");

--- a/WizardMakerTestbed/Models/CharacterManager.cs
+++ b/WizardMakerTestbed/Models/CharacterManager.cs
@@ -30,8 +30,7 @@ namespace WizardMakerPrototype.Models
             this.Character = new Character("New Character", "", startingAge);
             
             //TODO: Re-assess whether initializing a journal entry with "this" has a smell.
-            this.Character.addJournalable(new NewCharacterInitJournalEntry(startingAge, childhoodLanguage, 15));
-            
+            this.Character.addJournalable(new NewCharacterInitJournalEntry(startingAge, childhoodLanguage, Character.XpPerSeasonForInitialCreation));
 
             // TODO: Need a layer that will judge what abilities a character is even allowed to choose at any time (given that virtues and flaws can change this access).
             updateAbilityDuringCreation(childhoodLanguage.Name, NewCharacterInitJournalEntry.CHILDHOOD_LANGUAGE_XP, "");

--- a/WizardMakerTestbed/Models/CharacterManager.cs
+++ b/WizardMakerTestbed/Models/CharacterManager.cs
@@ -111,5 +111,11 @@ namespace WizardMakerPrototype.Models
 
             return new Character(rc);
         }
+
+        //TODO:  Do we need this anymore?
+        public static void RemoveLaterLifeXPPool(Character c)
+        {
+            c.XPPoolList.Remove(c.XPPoolList.Where(xppool => xppool.name == NewCharacterInitJournalEntry.LATER_LIFE_POOL_NAME).First());
+        }
     }
 }

--- a/WizardMakerTestbed/Models/CharacterRenderer.cs
+++ b/WizardMakerTestbed/Models/CharacterRenderer.cs
@@ -36,11 +36,14 @@ namespace WizardMakerPrototype.Models
          */
         public static void addAbility(Character character, string ability, int xp, string specialty, bool isIncrementalXP, string journalID)
         {
+            bool isPuissant = false;
+            if (character.puissantAbilities.Contains(ability)) { isPuissant = true; }
+
             if (!doesCharacterHaveAbility(character, ability))
             {
 
                 // add the ability to the character
-                character.abilities.Add(AbilityXPManager.createNewAbilityInstance(ability, xp, specialty, journalID));
+                character.abilities.Add(AbilityXPManager.createNewAbilityInstance(ability, xp, specialty, journalID, isPuissant));
             }
             else
             {

--- a/WizardMakerTestbed/Models/CharacterRenderer.cs
+++ b/WizardMakerTestbed/Models/CharacterRenderer.cs
@@ -21,6 +21,7 @@ namespace WizardMakerPrototype.Models
         {
             //Reset the Character
             character.resetAbilities();
+            // Perhaps we should be deleting the XP Pools rather than resetting?
             foreach (XPPool xPPool in character.XPPoolList) { xPPool.reset(); }
 
             foreach (Journalable journalable in character.GetJournal())

--- a/WizardMakerTestbed/Models/Journal/AddVirtueJournalEntry.cs
+++ b/WizardMakerTestbed/Models/Journal/AddVirtueJournalEntry.cs
@@ -13,6 +13,8 @@ namespace WizardMakerPrototype.Models.Journal
         public ArchVirtue archVirtue;
         public const string PREFIX = "Added virtue: ";
 
+        // secondary info is for cases where we have multiple virtues, such as Puissant Ability can actually be 
+        //  "Puissant Brawl" or "Puissant Area Lore: England"
         public AddVirtueJournalEntry(SeasonYear sy, ArchVirtue archVirtue)
         {
             this.text = new SimpleJournalEntry(PREFIX + archVirtue.Name, sy);

--- a/WizardMakerTestbed/Models/Journal/AddVirtueJournalEntry.cs
+++ b/WizardMakerTestbed/Models/Journal/AddVirtueJournalEntry.cs
@@ -21,7 +21,10 @@ namespace WizardMakerPrototype.Models.Journal
 
         public override void Execute(Character character)
         {
-            character.virtues.Add(new VirtueInstance(archVirtue));
+            VirtueInstance virtue = new VirtueInstance(archVirtue);
+            character.virtues.Add(virtue);
+            virtue.Virtue.characterCommand.Execute(character);
+
         }
 
         public override SeasonYear getDate()
@@ -42,6 +45,11 @@ namespace WizardMakerPrototype.Models.Journal
         public bool isMatch(string virtueName)
         {
             return (PREFIX + archVirtue.Name) == (PREFIX + virtueName);
+        }
+
+        public override int sortOrder()
+        {
+            return JournalSortingConstants.ADD_VIRTUE_SORT_ORDER;
         }
     }
 }

--- a/WizardMakerTestbed/Models/Journal/AddVirtueJournalEntry.cs
+++ b/WizardMakerTestbed/Models/Journal/AddVirtueJournalEntry.cs
@@ -11,6 +11,13 @@ namespace WizardMakerPrototype.Models.Journal
     {
         public SimpleJournalEntry text;
         public ArchVirtue archVirtue;
+        public const string PREFIX = "Added virtue: ";
+
+        public AddVirtueJournalEntry(SeasonYear sy, ArchVirtue archVirtue)
+        {
+            this.text = new SimpleJournalEntry(PREFIX + archVirtue.Name, sy);
+            this.archVirtue = archVirtue;
+        }
 
         public override void Execute(Character character)
         {
@@ -30,6 +37,11 @@ namespace WizardMakerPrototype.Models.Journal
         public override string getText()
         {
             return text.getText();
+        }
+
+        public bool isMatch(string virtueName)
+        {
+            return (PREFIX + archVirtue.Name) == (PREFIX + virtueName);
         }
     }
 }

--- a/WizardMakerTestbed/Models/Journal/AddVirtueJournalEntry.cs
+++ b/WizardMakerTestbed/Models/Journal/AddVirtueJournalEntry.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using WizardMakerPrototype.Models.Virtues;
+
+namespace WizardMakerPrototype.Models.Journal
+{
+    public class AddVirtueJournalEntry : Journalable
+    {
+        public SimpleJournalEntry text;
+        public ArchVirtue archVirtue;
+
+        public override void Execute(Character character)
+        {
+            character.virtues.Add(new VirtueInstance(archVirtue));
+        }
+
+        public override SeasonYear getDate()
+        {
+            return text.getDate();
+        }
+
+        public override string getId()
+        {
+            return text.getId();
+        }
+
+        public override string getText()
+        {
+            return text.getText();
+        }
+    }
+}

--- a/WizardMakerTestbed/Models/Journal/BasicJournalableManager.cs
+++ b/WizardMakerTestbed/Models/Journal/BasicJournalableManager.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
-
+using System.Linq;
 
 namespace WizardMakerPrototype.Models
 {
@@ -62,6 +62,24 @@ namespace WizardMakerPrototype.Models
                 }
             }
             journalables = result;
+        }
+
+        //TODO: Do we need this?  Delete if not.
+        public NewCharacterInitJournalEntry RetrieveCharacterInitJournalEntry()
+        {
+            try
+            {
+                NewCharacterInitJournalEntry result = (NewCharacterInitJournalEntry)journalables.ElementAt(0);
+                if (result == null)
+                {
+                    throw new InvalidCharacterInitializationException("Attempting to retrieve the character initialization journal entry when it does not exist.");
+                }
+                return result;
+            } catch (InvalidCastException ice)
+            {
+                throw new InvalidCharacterInitializationException("Attempting to retrieve the character initialization journal entry, but found another type instead: " 
+                    + journalables.ElementAt(0).GetType().Name + "(" + ice.Message +")");
+            }
         }
     }
 }

--- a/WizardMakerTestbed/Models/Journal/IJournalableManager.cs
+++ b/WizardMakerTestbed/Models/Journal/IJournalableManager.cs
@@ -25,25 +25,30 @@ namespace WizardMakerPrototype.Models
     {
         public int Compare(Journalable x, Journalable y)
         {
+            if (x.sortOrder() == y.sortOrder()) { 
 
-            if (x.getDate().Year == y.getDate().Year)
-            {
-                if (x.getDate().season == y.getDate().season)
+                if (x.getDate().Year == y.getDate().Year)
                 {
-                    if (x.getId() == y.getId())
+                    if (x.getDate().season == y.getDate().season)
                     {
-                        return new CaseInsensitiveComparer().Compare(x.getText(), y.getText());
-                    } else
-                    {
-                        return new CaseInsensitiveComparer().Compare(x.getId(), y.getId());
+                        if (x.getId() == y.getId())
+                        {
+                            return new CaseInsensitiveComparer().Compare(x.getText(), y.getText());
+                        }
+                        else
+                        {
+                            return new CaseInsensitiveComparer().Compare(x.getId(), y.getId());
+                        }
                     }
-                } else
-                {
-                    return x.getDate().season.CompareTo(y.getDate().season);
-                }
+                    else
+                    {
+                        return x.getDate().season.CompareTo(y.getDate().season);
+                    }
 
+                }
+                return x.getDate().Year.CompareTo(y.getDate().Year);
             }
-            return x.getDate().Year.CompareTo(y.getDate().Year);
+            return x.sortOrder().CompareTo(y.sortOrder());
         }
     }
 

--- a/WizardMakerTestbed/Models/Journal/JournalSortingConstants.cs
+++ b/WizardMakerTestbed/Models/Journal/JournalSortingConstants.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace WizardMakerPrototype.Models.Journal
+{
+    internal class JournalSortingConstants
+    {
+        // within the season year, how to sort.  Lower goes first.
+        public static int SEASON_YEAR_SORT_ORDER = 100;
+        public static int NEW_CHARACTER_INIT_SORT_ORDER = SEASON_YEAR_SORT_ORDER - 100;
+        public static int ADD_VIRTUE_SORT_ORDER = SEASON_YEAR_SORT_ORDER - 50;
+    }
+}

--- a/WizardMakerTestbed/Models/Journal/JournalSortingConstants.cs
+++ b/WizardMakerTestbed/Models/Journal/JournalSortingConstants.cs
@@ -8,9 +8,9 @@ namespace WizardMakerPrototype.Models.Journal
 {
     internal class JournalSortingConstants
     {
-        // within the season year, how to sort.  Lower goes first.
+        // within the season year, how to sort.  Lower goes first.  We want virtues to come before new character init, which defines XP Pools.
         public static int SEASON_YEAR_SORT_ORDER = 100;
-        public static int NEW_CHARACTER_INIT_SORT_ORDER = SEASON_YEAR_SORT_ORDER - 100;
-        public static int ADD_VIRTUE_SORT_ORDER = SEASON_YEAR_SORT_ORDER - 50;
+        public static int NEW_CHARACTER_INIT_SORT_ORDER = SEASON_YEAR_SORT_ORDER - 50;
+        public static int ADD_VIRTUE_SORT_ORDER = SEASON_YEAR_SORT_ORDER - 100;
     }
 }

--- a/WizardMakerTestbed/Models/Journal/Journalable.cs
+++ b/WizardMakerTestbed/Models/Journal/Journalable.cs
@@ -7,6 +7,11 @@ namespace WizardMakerPrototype.Models
     // TODO: Give it an ID field.  This way we can support searching and easier deletion.
     public abstract class Journalable: ICharacterCommand
     {
+        // This indicates that the sorting should be by the SeasonYear
+        //  For now, this is all journal entries.  Note that this also determines the 
+        //   order of rendering.
+        public const int SEASON_YEAR_SORT_ORDER = 100;
+
         public abstract string getText();
 
         public abstract SeasonYear getDate();
@@ -51,6 +56,11 @@ namespace WizardMakerPrototype.Models
             //  and each instance should have its own ID
 
             return true;
+        }
+
+        public virtual int sortOrder()
+        {
+            return SEASON_YEAR_SORT_ORDER;
         }
     }
 }

--- a/WizardMakerTestbed/Models/Journal/Journalable.cs
+++ b/WizardMakerTestbed/Models/Journal/Journalable.cs
@@ -1,6 +1,7 @@
 ﻿using Newtonsoft.Json;
 using System;
 using WizardMakerPrototype.Models;
+using WizardMakerPrototype.Models.Journal;
 
 namespace WizardMakerPrototype.Models
 {
@@ -9,8 +10,8 @@ namespace WizardMakerPrototype.Models
     {
         // This indicates that the sorting should be by the SeasonYear
         //  For now, this is all journal entries.  Note that this also determines the 
-        //   order of rendering.
-        public const int SEASON_YEAR_SORT_ORDER = 100;
+        //   order of rendering within the season.
+        
 
         public abstract string getText();
 
@@ -60,7 +61,7 @@ namespace WizardMakerPrototype.Models
 
         public virtual int sortOrder()
         {
-            return SEASON_YEAR_SORT_ORDER;
+            return JournalSortingConstants.SEASON_YEAR_SORT_ORDER;
         }
     }
 }

--- a/WizardMakerTestbed/Models/Journal/NewCharacterInitJournalEntry.cs
+++ b/WizardMakerTestbed/Models/Journal/NewCharacterInitJournalEntry.cs
@@ -38,10 +38,7 @@ namespace WizardMakerPrototype.Models
         public ArchAbility childhoodLanguage { get; set; }
         public int startingAge { get; set; } = 25;
 
-        // XP per year.  Eg, 20 for Wealthy.  Default is 15
-        public int xpPerYear { get; set; } = 15;
-
-        public NewCharacterInitJournalEntry(int startingAge, ArchAbility childhoodLanguage, int xpPerYear, int sagaYearStart = 1220)
+        public NewCharacterInitJournalEntry(int startingAge, ArchAbility childhoodLanguage, int sagaYearStart = 1220)
         {
             // TODO: Check that the starting language is a language.
             this.childhoodLanguage = childhoodLanguage;
@@ -49,7 +46,6 @@ namespace WizardMakerPrototype.Models
 
             // TODO: Make this have to do with starting Age and user-specified year.
             singleJournalEntry = new SimpleJournalEntry("Character initialized at age " + startingAge + " in " + (sagaYearStart - startingAge), new SeasonYear(sagaYearStart - startingAge, Season.SPRING));
-            this.xpPerYear = xpPerYear;
         }
 
         public override void Execute(Character character)
@@ -67,7 +63,7 @@ namespace WizardMakerPrototype.Models
                 new SpecificAbilitiesXpPool(CHILDHOOD_LANGUAGE_POOL_NAME, CHILDHOOD_LANGUAGE_DESCRIPTION + " (" + childhoodLanguage.Name + ")", 
                                             CHILDHOOD_LANGUAGE_XP, new List<ArchAbility>() { childhoodLanguage }),
                 new SpecificAbilitiesXpPool(CHILDHOOD_POOL_NAME, CHILDHOOD_DESCRIPTION, CHILDHOOD_XP, determineChildhoodAbilities()),
-                new BasicXPPool(LATER_LIFE_POOL_NAME, LATER_LIFE_DESCRIPTION, determineLaterLifeXp(this.startingAge)),
+                new BasicXPPool(LATER_LIFE_POOL_NAME, LATER_LIFE_DESCRIPTION, determineLaterLifeXp(character.startingAge, character.XpPerYear)),
                 new AllowOverdrawnXpPool()
                 };
 
@@ -77,7 +73,7 @@ namespace WizardMakerPrototype.Models
             }
         }
 
-        private int determineLaterLifeXp(int startingAge)
+        private int determineLaterLifeXp(int startingAge, int xpPerYear)
         {
             return Math.Max(0, (startingAge - CHILDHOOD_END_AGE) * xpPerYear);
         }

--- a/WizardMakerTestbed/Models/Journal/NewCharacterInitJournalEntry.cs
+++ b/WizardMakerTestbed/Models/Journal/NewCharacterInitJournalEntry.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
+using WizardMakerPrototype.Models.Journal;
 using WizardMakerTestbed.Models;
 
 [assembly: InternalsVisibleTo("WizardMakerTests")]
@@ -11,6 +12,7 @@ namespace WizardMakerPrototype.Models
      * TODO: Keep an eye that this class may better serve as a list of command instances to execute.
      * 
      * First journal entry for most characters.
+     * The order (ie, that this journal entry is first) must be maintained in code.
      */
     public class NewCharacterInitJournalEntry : Journalable
     {
@@ -23,7 +25,7 @@ namespace WizardMakerPrototype.Models
         private const string CHILDHOOD_DESCRIPTION = "XP granted to starting characters that can be spent on childhood skills";
         public const int CHILDHOOD_XP = 45;
 
-        private const string LATER_LIFE_POOL_NAME = "Later life XP Pool";
+        public static string LATER_LIFE_POOL_NAME = "Later life XP Pool";
         private const string LATER_LIFE_DESCRIPTION = "XP granted to starting characters that can be spent on anything the character can learn.  After age 5.";
         
         public static int CHILDHOOD_END_AGE = 5;
@@ -39,13 +41,14 @@ namespace WizardMakerPrototype.Models
         // XP per year.  Eg, 20 for Wealthy.  Default is 15
         public int xpPerYear { get; set; } = 15;
 
-        public NewCharacterInitJournalEntry(int startingAge, ArchAbility childhoodLanguage, int xpPerYear)
+        public NewCharacterInitJournalEntry(int startingAge, ArchAbility childhoodLanguage, int xpPerYear, int sagaYearStart = 1220)
         {
+            // TODO: Check that the starting language is a language.
             this.childhoodLanguage = childhoodLanguage;
             this.startingAge = startingAge;
 
             // TODO: Make this have to do with starting Age and user-specified year.
-            singleJournalEntry = new SimpleJournalEntry("Character initialized at age " + startingAge, new SeasonYear(1220-startingAge, Season.SPRING));
+            singleJournalEntry = new SimpleJournalEntry("Character initialized at age " + startingAge + " in " + (sagaYearStart - startingAge), new SeasonYear(sagaYearStart - startingAge, Season.SPRING));
             this.xpPerYear = xpPerYear;
         }
 
@@ -118,6 +121,11 @@ namespace WizardMakerPrototype.Models
             if (o2.startingAge != startingAge) return false;
             if (!o2.singleJournalEntry.IsSameSpecs(singleJournalEntry)) return false;
             return true;
+        }
+
+        public override int sortOrder()
+        {
+            return JournalSortingConstants.NEW_CHARACTER_INIT_SORT_ORDER;
         }
     }
 }

--- a/WizardMakerTestbed/Models/Journal/NewCharacterInitJournalEntry.cs
+++ b/WizardMakerTestbed/Models/Journal/NewCharacterInitJournalEntry.cs
@@ -28,7 +28,10 @@ namespace WizardMakerPrototype.Models
         
         public static int CHILDHOOD_END_AGE = 5;
 
-        public SingleJournalEntry singleJournalEntry { get; set; }
+        // Sort before the SeasonYear
+        public const int NEW_CHARACTER_INIT_SORT_ORDER = 50;
+
+        public SimpleJournalEntry singleJournalEntry { get; set; }
 
         public ArchAbility childhoodLanguage { get; set; }
         public int startingAge { get; set; } = 25;
@@ -42,7 +45,7 @@ namespace WizardMakerPrototype.Models
             this.startingAge = startingAge;
 
             // TODO: Make this have to do with starting Age and user-specified year.
-            singleJournalEntry = new SingleJournalEntry("Character initialized at age " + startingAge, new SeasonYear(1219, Season.SPRING));
+            singleJournalEntry = new SimpleJournalEntry("Character initialized at age " + startingAge, new SeasonYear(1220-startingAge, Season.SPRING));
             this.xpPerYear = xpPerYear;
         }
 

--- a/WizardMakerTestbed/Models/Journal/SimpleJournalEntry.cs
+++ b/WizardMakerTestbed/Models/Journal/SimpleJournalEntry.cs
@@ -31,13 +31,13 @@ namespace WizardMakerPrototype.Models
     /** Just a note with a season and year attached to it.
     * Does not actually do anything.
     */
-    public class SingleJournalEntry : Journalable
+    public class SimpleJournalEntry : Journalable
     {
         public string JournalEntryText { get; set; }
         public SeasonYear SeasonYear { get; set; }
         public String Id { get; }
 
-        public SingleJournalEntry(string journalEntryText, SeasonYear seasonYear)
+        public SimpleJournalEntry(string journalEntryText, SeasonYear seasonYear)
         {
             JournalEntryText = journalEntryText;
             SeasonYear = seasonYear;

--- a/WizardMakerTestbed/Models/Journal/XpAbilitySpendJournalEntry.cs
+++ b/WizardMakerTestbed/Models/Journal/XpAbilitySpendJournalEntry.cs
@@ -10,7 +10,7 @@ namespace WizardMakerPrototype.Models
     public class XpAbilitySpendJournalEntry : Journalable
     {
 
-        public SingleJournalEntry text;
+        public SimpleJournalEntry text;
         public string ability;
         public int xp;
         public string specialty; 
@@ -18,7 +18,7 @@ namespace WizardMakerPrototype.Models
         public XpAbilitySpendJournalEntry(string entry, SeasonYear sy, string ability, 
             int xp, string specialty)
         {
-            this.text = new SingleJournalEntry(entry, sy);
+            this.text = new SimpleJournalEntry(entry, sy);
 
             this.ability = ability;
             this.xp = xp;

--- a/WizardMakerTestbed/Models/Virtues/ArchVirtue.cs
+++ b/WizardMakerTestbed/Models/Virtues/ArchVirtue.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using WizardMakerPrototype.Models.Virtues.VirtueCommands;
 
 namespace WizardMakerPrototype.Models.Virtues
 {
@@ -43,13 +44,20 @@ namespace WizardMakerPrototype.Models.Virtues
         public string Description;
         public VirtueType Type;
         public VirtueMajorMinor MajorMinor;
+        public ICharacterCommand characterCommand { get; private set; }
 
-        public ArchVirtue(string name, string description, VirtueType type, VirtueMajorMinor majorMinor)
+        public static Dictionary<string, ArchVirtue> NameToArchVirtue = new Dictionary<string, ArchVirtue>();
+        public const string PUISSANT_PREFIX = "Puissant ";
+
+        public ArchVirtue(string name, string description, VirtueType type, VirtueMajorMinor majorMinor) : this(name, description, type, majorMinor, null) { }
+
+        public ArchVirtue(string name, string description, VirtueType type, VirtueMajorMinor majorMinor, ICharacterCommand characterCommand)
         {
             Name = name;
             Type = type;
             Description = description;
             MajorMinor = majorMinor;
+            this.characterCommand = characterCommand;
         }
 
         // TODO: In future, rather than a hard-coded list,
@@ -57,7 +65,14 @@ namespace WizardMakerPrototype.Models.Virtues
         // 
         // This will be especially needful, when considering "wildcard" Virtues which describe a list of many virtues, such as:
         //  Way of the (Land)
-
+        static ArchVirtue ()
+        {
+            // Implement puissant abilities as a dictionary to an arch virtue
+            foreach (ArchAbility a in ArchAbility.AllCommonAbilities)
+            {
+                NameToArchVirtue[PUISSANT_PREFIX + a.Name] = new ArchVirtue(PUISSANT_PREFIX + a.Name, "Puissant in the ability " + a.Name, VirtueType.General, VirtueMajorMinor.MINOR);
+            }
+        }
         public static ArchVirtue TheGift = new ArchVirtue("TheGift", "TheGift", VirtueType.Hermetic, VirtueMajorMinor.FREE);
         
         // Hermetic Major
@@ -91,7 +106,7 @@ namespace WizardMakerPrototype.Models.Virtues
         public static ArchVirtue GuardianAngel = new ArchVirtue("GuardianAngel", "GuardianAngel", VirtueType.General, VirtueMajorMinor.MAJOR);
         public static ArchVirtue TrueFaith = new ArchVirtue("TrueFaith", "TrueFaith", VirtueType.General, VirtueMajorMinor.MAJOR);
         public static ArchVirtue WaysoftheLand = new ArchVirtue("Waysofthe(Land)", "Waysofthe(Land)", VirtueType.General, VirtueMajorMinor.MAJOR);
-        public static ArchVirtue Wealthy = new ArchVirtue("Wealthy", "Wealthy", VirtueType.General, VirtueMajorMinor.MAJOR);
+        public static ArchVirtue Wealthy = new ArchVirtue("Wealthy", "Wealthy", VirtueType.General, VirtueMajorMinor.MAJOR, new WealthyCommand());
         
         // Hermetic Minor
         public static ArchVirtue AdeptLaboratoryStudent = new ArchVirtue("AdeptLaboratoryStudent", "AdeptLaboratoryStudent", VirtueType.Hermetic, VirtueMajorMinor.MINOR);

--- a/WizardMakerTestbed/Models/Virtues/ArchVirtue.cs
+++ b/WizardMakerTestbed/Models/Virtues/ArchVirtue.cs
@@ -46,8 +46,10 @@ namespace WizardMakerPrototype.Models.Virtues
         public VirtueMajorMinor MajorMinor;
         public ICharacterCommand characterCommand { get; private set; }
 
+        // Access ArchVirtue instances with this dictionary
         public static Dictionary<string, ArchVirtue> NameToArchVirtue = new Dictionary<string, ArchVirtue>();
         public const string PUISSANT_PREFIX = "Puissant ";
+        public const string AFFINITY_PREFIX = "Affinity with ";
 
         public ArchVirtue(string name, string description, VirtueType type, VirtueMajorMinor majorMinor) : this(name, description, type, majorMinor, null) { }
 
@@ -70,154 +72,316 @@ namespace WizardMakerPrototype.Models.Virtues
             // Implement puissant abilities as a dictionary to an arch virtue
             foreach (ArchAbility a in ArchAbility.AllCommonAbilities)
             {
-                NameToArchVirtue[PUISSANT_PREFIX + a.Name] = new ArchVirtue(PUISSANT_PREFIX + a.Name, "Puissant in the ability " + a.Name, VirtueType.General, VirtueMajorMinor.MINOR);
+                NameToArchVirtue[PUISSANT_PREFIX + a.Name] = new ArchVirtue(PUISSANT_PREFIX + a.Name, "Puissant in the ability " + a.Name, VirtueType.General, 
+                    VirtueMajorMinor.MINOR, new PuissantAbilityCommand(a));
+                NameToArchVirtue[AFFINITY_PREFIX + a.Name] = new ArchVirtue(AFFINITY_PREFIX + a.Name, "Affinity with the ability " + a.Name, VirtueType.Hermetic, VirtueMajorMinor.MINOR);
             }
+            PopulateVirtueDictionary();
+
         }
-        public static ArchVirtue TheGift = new ArchVirtue("TheGift", "TheGift", VirtueType.Hermetic, VirtueMajorMinor.FREE);
+
+        // TODO: Define the keys as constants
+
+        #region Individual ArchVirtue Instances
+        private static ArchVirtue TheGift = new ArchVirtue("TheGift", "TheGift", VirtueType.Hermetic, VirtueMajorMinor.FREE);
         
         // Hermetic Major
-        public static ArchVirtue DiedneMagic = new ArchVirtue("DiedneMagic", "DiedneMagic", VirtueType.Hermetic, VirtueMajorMinor.MAJOR);
-        public static ArchVirtue ElementalMagic = new ArchVirtue("ElementalMagic", "ElementalMagic", VirtueType.Hermetic, VirtueMajorMinor.MAJOR);
-        public static ArchVirtue FlawlessMagic = new ArchVirtue("FlawlessMagic", "FlawlessMagic", VirtueType.Hermetic, VirtueMajorMinor.MAJOR);
-        public static ArchVirtue FlexibleFormulaicMagic = new ArchVirtue("FlexibleFormulaicMagic", "FlexibleFormulaicMagic", VirtueType.Hermetic, VirtueMajorMinor.MAJOR);
-        public static ArchVirtue GentleGift = new ArchVirtue("GentleGift", "GentleGift", VirtueType.Hermetic, VirtueMajorMinor.MAJOR);
-        public static ArchVirtue LifeLinkedSpontaneousMagic = new ArchVirtue("Life-LinkedSpontaneousMagic", "Life-LinkedSpontaneousMagic", VirtueType.Hermetic, VirtueMajorMinor.MAJOR);
-        public static ArchVirtue MajorMagicalFocus = new ArchVirtue("MajorMagicalFocus", "MajorMagicalFocus", VirtueType.Hermetic, VirtueMajorMinor.MAJOR);
-        public static ArchVirtue MercurianMagic = new ArchVirtue("MercurianMagic", "MercurianMagic", VirtueType.Hermetic, VirtueMajorMinor.MAJOR);
-        public static ArchVirtue MythicBlood = new ArchVirtue("MythicBlood", "MythicBlood", VirtueType.Hermetic, VirtueMajorMinor.MAJOR);
-        public static ArchVirtue SecondaryInsight = new ArchVirtue("SecondaryInsight", "SecondaryInsight", VirtueType.Hermetic, VirtueMajorMinor.MAJOR);
+        private static ArchVirtue DiedneMagic = new ArchVirtue("DiedneMagic", "DiedneMagic", VirtueType.Hermetic, VirtueMajorMinor.MAJOR);
+        private static ArchVirtue ElementalMagic = new ArchVirtue("ElementalMagic", "ElementalMagic", VirtueType.Hermetic, VirtueMajorMinor.MAJOR);
+        private static ArchVirtue FlawlessMagic = new ArchVirtue("FlawlessMagic", "FlawlessMagic", VirtueType.Hermetic, VirtueMajorMinor.MAJOR);
+        private static ArchVirtue FlexibleFormulaicMagic = new ArchVirtue("FlexibleFormulaicMagic", "FlexibleFormulaicMagic", VirtueType.Hermetic, VirtueMajorMinor.MAJOR);
+        private static ArchVirtue GentleGift = new ArchVirtue("GentleGift", "GentleGift", VirtueType.Hermetic, VirtueMajorMinor.MAJOR);
+        private static ArchVirtue LifeLinkedSpontaneousMagic = new ArchVirtue("Life-LinkedSpontaneousMagic", "Life-LinkedSpontaneousMagic", VirtueType.Hermetic, VirtueMajorMinor.MAJOR);
+        private static ArchVirtue MajorMagicalFocus = new ArchVirtue("MajorMagicalFocus", "MajorMagicalFocus", VirtueType.Hermetic, VirtueMajorMinor.MAJOR);
+        private static ArchVirtue MercurianMagic = new ArchVirtue("MercurianMagic", "MercurianMagic", VirtueType.Hermetic, VirtueMajorMinor.MAJOR);
+        private static ArchVirtue MythicBlood = new ArchVirtue("MythicBlood", "MythicBlood", VirtueType.Hermetic, VirtueMajorMinor.MAJOR);
+        private static ArchVirtue SecondaryInsight = new ArchVirtue("SecondaryInsight", "SecondaryInsight", VirtueType.Hermetic, VirtueMajorMinor.MAJOR);
         
         // Supernatural Major
-        public static ArchVirtue Entrancement = new ArchVirtue("Entrancement", "Entrancement", VirtueType.Supernatural, VirtueMajorMinor.MAJOR);
-        public static ArchVirtue GreaterImmunity = new ArchVirtue("GreaterImmunity", "GreaterImmunity", VirtueType.Supernatural, VirtueMajorMinor.MAJOR);
-        public static ArchVirtue GreaterPurifyingTouch = new ArchVirtue("GreaterPurifyingTouch", "GreaterPurifyingTouch", VirtueType.Supernatural, VirtueMajorMinor.MAJOR);
-        public static ArchVirtue Shapeshifter = new ArchVirtue("Shapeshifter", "Shapeshifter", VirtueType.Supernatural, VirtueMajorMinor.MAJOR);
-        public static ArchVirtue StrongFaerieBlood = new ArchVirtue("StrongFaerieBlood", "StrongFaerieBlood", VirtueType.Supernatural, VirtueMajorMinor.MAJOR);
+        private static ArchVirtue Entrancement = new ArchVirtue("Entrancement", "Entrancement", VirtueType.Supernatural, VirtueMajorMinor.MAJOR);
+        private static ArchVirtue GreaterImmunity = new ArchVirtue("GreaterImmunity", "GreaterImmunity", VirtueType.Supernatural, VirtueMajorMinor.MAJOR);
+        private static ArchVirtue GreaterPurifyingTouch = new ArchVirtue("GreaterPurifyingTouch", "GreaterPurifyingTouch", VirtueType.Supernatural, VirtueMajorMinor.MAJOR);
+        private static ArchVirtue Shapeshifter = new ArchVirtue("Shapeshifter", "Shapeshifter", VirtueType.Supernatural, VirtueMajorMinor.MAJOR);
+        private static ArchVirtue StrongFaerieBlood = new ArchVirtue("StrongFaerieBlood", "StrongFaerieBlood", VirtueType.Supernatural, VirtueMajorMinor.MAJOR);
         
         // Social Status Major
-        public static ArchVirtue LandedNoble = new ArchVirtue("LandedNoble", "LandedNoble", VirtueType.Social, VirtueMajorMinor.MAJOR);
-        public static ArchVirtue MagisterinArtibus = new ArchVirtue("MagisterinArtibus", "MagisterinArtibus", VirtueType.Social, VirtueMajorMinor.MAJOR);
-        public static ArchVirtue Redcap = new ArchVirtue("Redcap", "Redcap", VirtueType.Social, VirtueMajorMinor.MAJOR);
+        private static ArchVirtue LandedNoble = new ArchVirtue("LandedNoble", "LandedNoble", VirtueType.Social, VirtueMajorMinor.MAJOR);
+        private static ArchVirtue MagisterinArtibus = new ArchVirtue("MagisterinArtibus", "MagisterinArtibus", VirtueType.Social, VirtueMajorMinor.MAJOR);
+        private static ArchVirtue Redcap = new ArchVirtue("Redcap", "Redcap", VirtueType.Social, VirtueMajorMinor.MAJOR);
         
         // General Major
-        public static ArchVirtue DeathProphecy = new ArchVirtue("DeathProphecy", "DeathProphecy", VirtueType.General, VirtueMajorMinor.MAJOR);
-        public static ArchVirtue GhostlyWarder = new ArchVirtue("GhostlyWarder", "GhostlyWarder", VirtueType.General, VirtueMajorMinor.MAJOR);
-        public static ArchVirtue GiantBlood = new ArchVirtue("GiantBlood", "GiantBlood", VirtueType.General, VirtueMajorMinor.MAJOR);
-        public static ArchVirtue GuardianAngel = new ArchVirtue("GuardianAngel", "GuardianAngel", VirtueType.General, VirtueMajorMinor.MAJOR);
-        public static ArchVirtue TrueFaith = new ArchVirtue("TrueFaith", "TrueFaith", VirtueType.General, VirtueMajorMinor.MAJOR);
-        public static ArchVirtue WaysoftheLand = new ArchVirtue("Waysofthe(Land)", "Waysofthe(Land)", VirtueType.General, VirtueMajorMinor.MAJOR);
-        public static ArchVirtue Wealthy = new ArchVirtue("Wealthy", "Wealthy", VirtueType.General, VirtueMajorMinor.MAJOR, new WealthyCommand());
+        private static ArchVirtue DeathProphecy = new ArchVirtue("DeathProphecy", "DeathProphecy", VirtueType.General, VirtueMajorMinor.MAJOR);
+        private static ArchVirtue GhostlyWarder = new ArchVirtue("GhostlyWarder", "GhostlyWarder", VirtueType.General, VirtueMajorMinor.MAJOR);
+        private static ArchVirtue GiantBlood = new ArchVirtue("GiantBlood", "GiantBlood", VirtueType.General, VirtueMajorMinor.MAJOR);
+        private static ArchVirtue GuardianAngel = new ArchVirtue("GuardianAngel", "GuardianAngel", VirtueType.General, VirtueMajorMinor.MAJOR);
+        private static ArchVirtue TrueFaith = new ArchVirtue("TrueFaith", "TrueFaith", VirtueType.General, VirtueMajorMinor.MAJOR);
+        private static ArchVirtue WaysoftheLand = new ArchVirtue("Waysofthe(Land)", "Waysofthe(Land)", VirtueType.General, VirtueMajorMinor.MAJOR);
+        private static ArchVirtue Wealthy = new ArchVirtue("Wealthy", "Wealthy", VirtueType.General, VirtueMajorMinor.MAJOR, new WealthyCommand());
         
         // Hermetic Minor
-        public static ArchVirtue AdeptLaboratoryStudent = new ArchVirtue("AdeptLaboratoryStudent", "AdeptLaboratoryStudent", VirtueType.Hermetic, VirtueMajorMinor.MINOR);
-        public static ArchVirtue AffinitywithArt = new ArchVirtue("AffinitywithArt", "AffinitywithArt", VirtueType.Hermetic, VirtueMajorMinor.MINOR);
-        public static ArchVirtue CautiousSorcerer = new ArchVirtue("CautiousSorcerer", "CautiousSorcerer", VirtueType.Hermetic, VirtueMajorMinor.MINOR);
-        public static ArchVirtue CyclicMagicpositive = new ArchVirtue("CyclicMagic(positive)", "CyclicMagic(positive)", VirtueType.Hermetic, VirtueMajorMinor.MINOR);
-        public static ArchVirtue DeftForm = new ArchVirtue("DeftForm", "DeftForm", VirtueType.Hermetic, VirtueMajorMinor.MINOR);
-        public static ArchVirtue EnduringMagic = new ArchVirtue("EnduringMagic", "EnduringMagic", VirtueType.Hermetic, VirtueMajorMinor.MINOR);
-        public static ArchVirtue TheEnigma = new ArchVirtue("TheEnigma", "TheEnigma", VirtueType.Hermetic, VirtueMajorMinor.MINOR);
-        public static ArchVirtue FaerieMagic = new ArchVirtue("FaerieMagic", "FaerieMagic", VirtueType.Hermetic, VirtueMajorMinor.MINOR);
-        public static ArchVirtue FastCaster = new ArchVirtue("FastCaster", "FastCaster", VirtueType.Hermetic, VirtueMajorMinor.MINOR);
-        public static ArchVirtue FreeStudy = new ArchVirtue("FreeStudy", "FreeStudy", VirtueType.Hermetic, VirtueMajorMinor.MINOR);
-        public static ArchVirtue HarnessedMagic = new ArchVirtue("HarnessedMagic", "HarnessedMagic", VirtueType.Hermetic, VirtueMajorMinor.MINOR);
-        public static ArchVirtue Heartbeast = new ArchVirtue("Heartbeast", "Heartbeast", VirtueType.Hermetic, VirtueMajorMinor.MINOR);
-        public static ArchVirtue HermeticPrestige = new ArchVirtue("HermeticPrestige", "HermeticPrestige", VirtueType.Hermetic, VirtueMajorMinor.MINOR);
-        public static ArchVirtue InoffensivetoAnimals = new ArchVirtue("InoffensivetoAnimals", "InoffensivetoAnimals", VirtueType.Hermetic, VirtueMajorMinor.MINOR);
-        public static ArchVirtue InventiveGenius = new ArchVirtue("InventiveGenius", "InventiveGenius", VirtueType.Hermetic, VirtueMajorMinor.MINOR);
-        public static ArchVirtue LifeBoost = new ArchVirtue("LifeBoost", "LifeBoost", VirtueType.Hermetic, VirtueMajorMinor.MINOR);
-        public static ArchVirtue MinorMagicalFocus = new ArchVirtue("MinorMagicalFocus", "MinorMagicalFocus", VirtueType.Hermetic, VirtueMajorMinor.MINOR);
-        public static ArchVirtue MagicalMemory = new ArchVirtue("MagicalMemory", "MagicalMemory", VirtueType.Hermetic, VirtueMajorMinor.MINOR);
-        public static ArchVirtue MasteredSpells = new ArchVirtue("MasteredSpells", "MasteredSpells", VirtueType.Hermetic, VirtueMajorMinor.MINOR);
-        public static ArchVirtue MethodCaster = new ArchVirtue("MethodCaster", "MethodCaster", VirtueType.Hermetic, VirtueMajorMinor.MINOR);
-        public static ArchVirtue PersonalVisSource = new ArchVirtue("PersonalVisSource", "PersonalVisSource", VirtueType.Hermetic, VirtueMajorMinor.MINOR);
-        public static ArchVirtue PuissantArt = new ArchVirtue("PuissantArt", "PuissantArt", VirtueType.Hermetic, VirtueMajorMinor.MINOR);
-        public static ArchVirtue QuietMagic = new ArchVirtue("QuietMagic", "QuietMagic", VirtueType.Hermetic, VirtueMajorMinor.MINOR);
-        public static ArchVirtue SideEffect = new ArchVirtue("SideEffect", "SideEffect", VirtueType.Hermetic, VirtueMajorMinor.MINOR);
-        public static ArchVirtue SkilledParens = new ArchVirtue("SkilledParens", "SkilledParens", VirtueType.Hermetic, VirtueMajorMinor.MINOR);
-        public static ArchVirtue SpecialCircumstances = new ArchVirtue("SpecialCircumstances", "SpecialCircumstances", VirtueType.Hermetic, VirtueMajorMinor.MINOR);
-        public static ArchVirtue StudyBonus = new ArchVirtue("StudyBonus", "StudyBonus", VirtueType.Hermetic, VirtueMajorMinor.MINOR);
-        public static ArchVirtue SubtleMagic = new ArchVirtue("SubtleMagic", "SubtleMagic", VirtueType.Hermetic, VirtueMajorMinor.MINOR);
-        public static ArchVirtue VerditiusMagic = new ArchVirtue("VerditiusMagic", "VerditiusMagic", VirtueType.Hermetic, VirtueMajorMinor.MINOR);
+        private static ArchVirtue AdeptLaboratoryStudent = new ArchVirtue("AdeptLaboratoryStudent", "AdeptLaboratoryStudent", VirtueType.Hermetic, VirtueMajorMinor.MINOR);
+        private static ArchVirtue AffinitywithArt = new ArchVirtue("AffinitywithArt", "AffinitywithArt", VirtueType.Hermetic, VirtueMajorMinor.MINOR);
+        private static ArchVirtue CautiousSorcerer = new ArchVirtue("CautiousSorcerer", "CautiousSorcerer", VirtueType.Hermetic, VirtueMajorMinor.MINOR);
+        private static ArchVirtue CyclicMagicpositive = new ArchVirtue("CyclicMagic(positive)", "CyclicMagic(positive)", VirtueType.Hermetic, VirtueMajorMinor.MINOR);
+        private static ArchVirtue DeftForm = new ArchVirtue("DeftForm", "DeftForm", VirtueType.Hermetic, VirtueMajorMinor.MINOR);
+        private static ArchVirtue EnduringMagic = new ArchVirtue("EnduringMagic", "EnduringMagic", VirtueType.Hermetic, VirtueMajorMinor.MINOR);
+        private static ArchVirtue TheEnigma = new ArchVirtue("TheEnigma", "TheEnigma", VirtueType.Hermetic, VirtueMajorMinor.MINOR);
+        private static ArchVirtue FaerieMagic = new ArchVirtue("FaerieMagic", "FaerieMagic", VirtueType.Hermetic, VirtueMajorMinor.MINOR);
+        private static ArchVirtue FastCaster = new ArchVirtue("FastCaster", "FastCaster", VirtueType.Hermetic, VirtueMajorMinor.MINOR);
+        private static ArchVirtue FreeStudy = new ArchVirtue("FreeStudy", "FreeStudy", VirtueType.Hermetic, VirtueMajorMinor.MINOR);
+        private static ArchVirtue HarnessedMagic = new ArchVirtue("HarnessedMagic", "HarnessedMagic", VirtueType.Hermetic, VirtueMajorMinor.MINOR);
+        private static ArchVirtue Heartbeast = new ArchVirtue("Heartbeast", "Heartbeast", VirtueType.Hermetic, VirtueMajorMinor.MINOR);
+        private static ArchVirtue HermeticPrestige = new ArchVirtue("HermeticPrestige", "HermeticPrestige", VirtueType.Hermetic, VirtueMajorMinor.MINOR);
+        private static ArchVirtue InoffensivetoAnimals = new ArchVirtue("InoffensivetoAnimals", "InoffensivetoAnimals", VirtueType.Hermetic, VirtueMajorMinor.MINOR);
+        private static ArchVirtue InventiveGenius = new ArchVirtue("InventiveGenius", "InventiveGenius", VirtueType.Hermetic, VirtueMajorMinor.MINOR);
+        private static ArchVirtue LifeBoost = new ArchVirtue("LifeBoost", "LifeBoost", VirtueType.Hermetic, VirtueMajorMinor.MINOR);
+        private static ArchVirtue MinorMagicalFocus = new ArchVirtue("MinorMagicalFocus", "MinorMagicalFocus", VirtueType.Hermetic, VirtueMajorMinor.MINOR);
+        private static ArchVirtue MagicalMemory = new ArchVirtue("MagicalMemory", "MagicalMemory", VirtueType.Hermetic, VirtueMajorMinor.MINOR);
+        private static ArchVirtue MasteredSpells = new ArchVirtue("MasteredSpells", "MasteredSpells", VirtueType.Hermetic, VirtueMajorMinor.MINOR);
+        private static ArchVirtue MethodCaster = new ArchVirtue("MethodCaster", "MethodCaster", VirtueType.Hermetic, VirtueMajorMinor.MINOR);
+        private static ArchVirtue PersonalVisSource = new ArchVirtue("PersonalVisSource", "PersonalVisSource", VirtueType.Hermetic, VirtueMajorMinor.MINOR);
+        private static ArchVirtue PuissantArt = new ArchVirtue("PuissantArt", "PuissantArt", VirtueType.Hermetic, VirtueMajorMinor.MINOR);
+        private static ArchVirtue QuietMagic = new ArchVirtue("QuietMagic", "QuietMagic", VirtueType.Hermetic, VirtueMajorMinor.MINOR);
+        private static ArchVirtue SideEffect = new ArchVirtue("SideEffect", "SideEffect", VirtueType.Hermetic, VirtueMajorMinor.MINOR);
+        private static ArchVirtue SkilledParens = new ArchVirtue("SkilledParens", "SkilledParens", VirtueType.Hermetic, VirtueMajorMinor.MINOR);
+        private static ArchVirtue SpecialCircumstances = new ArchVirtue("SpecialCircumstances", "SpecialCircumstances", VirtueType.Hermetic, VirtueMajorMinor.MINOR);
+        private static ArchVirtue StudyBonus = new ArchVirtue("StudyBonus", "StudyBonus", VirtueType.Hermetic, VirtueMajorMinor.MINOR);
+        private static ArchVirtue SubtleMagic = new ArchVirtue("SubtleMagic", "SubtleMagic", VirtueType.Hermetic, VirtueMajorMinor.MINOR);
+        private static ArchVirtue VerditiusMagic = new ArchVirtue("VerditiusMagic", "VerditiusMagic", VirtueType.Hermetic, VirtueMajorMinor.MINOR);
         
         // Supernatural Minor
-        public static ArchVirtue AnimalKen = new ArchVirtue("AnimalKen", "AnimalKen", VirtueType.Supernatural, VirtueMajorMinor.MINOR);
-        public static ArchVirtue Dowsing = new ArchVirtue("Dowsing", "Dowsing", VirtueType.Supernatural, VirtueMajorMinor.MINOR);
-        public static ArchVirtue EnchantingMusic = new ArchVirtue("EnchantingMusic", "EnchantingMusic", VirtueType.Supernatural, VirtueMajorMinor.MINOR);
-        public static ArchVirtue LesserImmunity = new ArchVirtue("LesserImmunity", "LesserImmunity", VirtueType.Supernatural, VirtueMajorMinor.MINOR);
-        public static ArchVirtue LesserPurifyingTouch = new ArchVirtue("LesserPurifyingTouch", "LesserPurifyingTouch", VirtueType.Supernatural, VirtueMajorMinor.MINOR);
-        public static ArchVirtue MagicSensitivity = new ArchVirtue("MagicSensitivity", "MagicSensitivity", VirtueType.Supernatural, VirtueMajorMinor.MINOR);
-        public static ArchVirtue Premonitions = new ArchVirtue("Premonitions", "Premonitions", VirtueType.Supernatural, VirtueMajorMinor.MINOR);
-        public static ArchVirtue SecondSight = new ArchVirtue("SecondSight", "SecondSight", VirtueType.Supernatural, VirtueMajorMinor.MINOR);
-        public static ArchVirtue SenseHolinessandUnholiness = new ArchVirtue("SenseHolinessandUnholiness", "SenseHolinessandUnholiness", VirtueType.Supernatural, VirtueMajorMinor.MINOR);
-        public static ArchVirtue Skinchanger = new ArchVirtue("Skinchanger", "Skinchanger", VirtueType.Supernatural, VirtueMajorMinor.MINOR);
-        public static ArchVirtue WildernessSense = new ArchVirtue("WildernessSense", "WildernessSense", VirtueType.Supernatural, VirtueMajorMinor.MINOR);
+        private static ArchVirtue AnimalKen = new ArchVirtue("AnimalKen", "AnimalKen", VirtueType.Supernatural, VirtueMajorMinor.MINOR);
+        private static ArchVirtue Dowsing = new ArchVirtue("Dowsing", "Dowsing", VirtueType.Supernatural, VirtueMajorMinor.MINOR);
+        private static ArchVirtue EnchantingMusic = new ArchVirtue("EnchantingMusic", "EnchantingMusic", VirtueType.Supernatural, VirtueMajorMinor.MINOR);
+        private static ArchVirtue LesserImmunity = new ArchVirtue("LesserImmunity", "LesserImmunity", VirtueType.Supernatural, VirtueMajorMinor.MINOR);
+        private static ArchVirtue LesserPurifyingTouch = new ArchVirtue("LesserPurifyingTouch", "LesserPurifyingTouch", VirtueType.Supernatural, VirtueMajorMinor.MINOR);
+        private static ArchVirtue MagicSensitivity = new ArchVirtue("MagicSensitivity", "MagicSensitivity", VirtueType.Supernatural, VirtueMajorMinor.MINOR);
+        private static ArchVirtue Premonitions = new ArchVirtue("Premonitions", "Premonitions", VirtueType.Supernatural, VirtueMajorMinor.MINOR);
+        private static ArchVirtue SecondSight = new ArchVirtue("SecondSight", "SecondSight", VirtueType.Supernatural, VirtueMajorMinor.MINOR);
+        private static ArchVirtue SenseHolinessandUnholiness = new ArchVirtue("SenseHolinessandUnholiness", "SenseHolinessandUnholiness", VirtueType.Supernatural, VirtueMajorMinor.MINOR);
+        private static ArchVirtue Skinchanger = new ArchVirtue("Skinchanger", "Skinchanger", VirtueType.Supernatural, VirtueMajorMinor.MINOR);
+        private static ArchVirtue WildernessSense = new ArchVirtue("WildernessSense", "WildernessSense", VirtueType.Supernatural, VirtueMajorMinor.MINOR);
         
         // Social Minor
-        public static ArchVirtue Clerk = new ArchVirtue("Clerk", "Clerk", VirtueType.Social, VirtueMajorMinor.MINOR);
-        public static ArchVirtue Custos = new ArchVirtue("Custos", "Custos", VirtueType.Social, VirtueMajorMinor.MINOR);
-        public static ArchVirtue FailedApprentice = new ArchVirtue("FailedApprentice", "FailedApprentice", VirtueType.Social, VirtueMajorMinor.MINOR);
-        public static ArchVirtue Gentlemanwoman = new ArchVirtue("Gentleman/woman", "Gentleman/woman", VirtueType.Social, VirtueMajorMinor.MINOR);
-        public static ArchVirtue Knight = new ArchVirtue("Knight", "Knight", VirtueType.Social, VirtueMajorMinor.MINOR);
-        public static ArchVirtue MendicantFriar = new ArchVirtue("MendicantFriar", "MendicantFriar", VirtueType.Social, VirtueMajorMinor.MINOR);
-        public static ArchVirtue MercenaryCaptain = new ArchVirtue("MercenaryCaptain", "MercenaryCaptain", VirtueType.Social, VirtueMajorMinor.MINOR);
-        public static ArchVirtue Priest = new ArchVirtue("Priest", "Priest", VirtueType.Social, VirtueMajorMinor.MINOR);
-        public static ArchVirtue WiseOne = new ArchVirtue("WiseOne", "WiseOne", VirtueType.Social, VirtueMajorMinor.MINOR);
+        private static ArchVirtue Clerk = new ArchVirtue("Clerk", "Clerk", VirtueType.Social, VirtueMajorMinor.MINOR);
+        private static ArchVirtue Custos = new ArchVirtue("Custos", "Custos", VirtueType.Social, VirtueMajorMinor.MINOR);
+        private static ArchVirtue FailedApprentice = new ArchVirtue("FailedApprentice", "FailedApprentice", VirtueType.Social, VirtueMajorMinor.MINOR);
+        private static ArchVirtue Gentlemanwoman = new ArchVirtue("Gentleman/woman", "Gentleman/woman", VirtueType.Social, VirtueMajorMinor.MINOR);
+        private static ArchVirtue Knight = new ArchVirtue("Knight", "Knight", VirtueType.Social, VirtueMajorMinor.MINOR);
+        private static ArchVirtue MendicantFriar = new ArchVirtue("MendicantFriar", "MendicantFriar", VirtueType.Social, VirtueMajorMinor.MINOR);
+        private static ArchVirtue MercenaryCaptain = new ArchVirtue("MercenaryCaptain", "MercenaryCaptain", VirtueType.Social, VirtueMajorMinor.MINOR);
+        private static ArchVirtue Priest = new ArchVirtue("Priest", "Priest", VirtueType.Social, VirtueMajorMinor.MINOR);
+        private static ArchVirtue WiseOne = new ArchVirtue("WiseOne", "WiseOne", VirtueType.Social, VirtueMajorMinor.MINOR);
         
         // General Minor
-        public static ArchVirtue AffinitywithAbility = new ArchVirtue("AffinitywithAbility", "AffinitywithAbility", VirtueType.General, VirtueMajorMinor.MINOR);
-        public static ArchVirtue AptStudent = new ArchVirtue("AptStudent", "AptStudent", VirtueType.General, VirtueMajorMinor.MINOR);
-        public static ArchVirtue ArcaneLore = new ArchVirtue("ArcaneLore", "ArcaneLore", VirtueType.General, VirtueMajorMinor.MINOR);
-        public static ArchVirtue Berserk = new ArchVirtue("Berserk", "Berserk", VirtueType.General, VirtueMajorMinor.MINOR);
-        public static ArchVirtue BookLearner = new ArchVirtue("BookLearner", "BookLearner", VirtueType.General, VirtueMajorMinor.MINOR);
-        public static ArchVirtue CautiouswithAbility = new ArchVirtue("CautiouswithAbility", "CautiouswithAbility", VirtueType.General, VirtueMajorMinor.MINOR);
-        public static ArchVirtue ClearThinker = new ArchVirtue("ClearThinker", "ClearThinker", VirtueType.General, VirtueMajorMinor.MINOR);
-        public static ArchVirtue CommonSense = new ArchVirtue("CommonSense", "CommonSense", VirtueType.General, VirtueMajorMinor.MINOR);
-        public static ArchVirtue Educated = new ArchVirtue("Educated", "Educated", VirtueType.General, VirtueMajorMinor.MINOR);
-        public static ArchVirtue EnduringConstitution = new ArchVirtue("EnduringConstitution", "EnduringConstitution", VirtueType.General, VirtueMajorMinor.MINOR);
-        public static ArchVirtue FaerieBlood = new ArchVirtue("FaerieBlood", "FaerieBlood", VirtueType.General, VirtueMajorMinor.MINOR);
-        public static ArchVirtue Famous = new ArchVirtue("Famous", "Famous", VirtueType.General, VirtueMajorMinor.MINOR);
-        public static ArchVirtue FreeExpression = new ArchVirtue("FreeExpression", "FreeExpression", VirtueType.General, VirtueMajorMinor.MINOR);
-        public static ArchVirtue GoodTeacher = new ArchVirtue("GoodTeacher", "GoodTeacher", VirtueType.General, VirtueMajorMinor.MINOR);
-        public static ArchVirtue Gossip = new ArchVirtue("Gossip", "Gossip", VirtueType.General, VirtueMajorMinor.MINOR);
-        public static ArchVirtue ImprovedCharacteristics = new ArchVirtue("ImprovedCharacteristics", "ImprovedCharacteristics", VirtueType.General, VirtueMajorMinor.MINOR);
-        public static ArchVirtue Inspirational = new ArchVirtue("Inspirational", "Inspirational", VirtueType.General, VirtueMajorMinor.MINOR);
-        public static ArchVirtue Intuition = new ArchVirtue("Intuition", "Intuition", VirtueType.General, VirtueMajorMinor.MINOR);
-        public static ArchVirtue KeenVision = new ArchVirtue("KeenVision", "KeenVision", VirtueType.General, VirtueMajorMinor.MINOR);
-        public static ArchVirtue Large = new ArchVirtue("Large", "Large", VirtueType.General, VirtueMajorMinor.MINOR);
-        public static ArchVirtue LatentMagicalAbility = new ArchVirtue("LatentMagicalAbility", "LatentMagicalAbility", VirtueType.General, VirtueMajorMinor.MINOR);
-        public static ArchVirtue LearnAbilityfromMistakes = new ArchVirtue("Learn(Ability)fromMistakes", "Learn(Ability)fromMistakes", VirtueType.General, VirtueMajorMinor.MINOR);
-        public static ArchVirtue LightTouch = new ArchVirtue("LightTouch", "LightTouch", VirtueType.General, VirtueMajorMinor.MINOR);
-        public static ArchVirtue LightningReflexes = new ArchVirtue("LightningReflexes", "LightningReflexes", VirtueType.General, VirtueMajorMinor.MINOR);
-        public static ArchVirtue LongWinded = new ArchVirtue("Long-Winded", "Long-Winded", VirtueType.General, VirtueMajorMinor.MINOR);
-        public static ArchVirtue Luck = new ArchVirtue("Luck", "Luck", VirtueType.General, VirtueMajorMinor.MINOR);
-        public static ArchVirtue RapidConvalescence = new ArchVirtue("RapidConvalescence", "RapidConvalescence", VirtueType.General, VirtueMajorMinor.MINOR);
-        public static ArchVirtue PerfectBalance = new ArchVirtue("PerfectBalance", "PerfectBalance", VirtueType.General, VirtueMajorMinor.MINOR);
-        public static ArchVirtue PiercingGaze = new ArchVirtue("PiercingGaze", "PiercingGaze", VirtueType.General, VirtueMajorMinor.MINOR);
-        public static ArchVirtue PrivilegedUpbringing = new ArchVirtue("PrivilegedUpbringing", "PrivilegedUpbringing", VirtueType.General, VirtueMajorMinor.MINOR);
-        public static ArchVirtue Protection = new ArchVirtue("Protection", "Protection", VirtueType.General, VirtueMajorMinor.MINOR);
-        public static ArchVirtue PuissantAbility = new ArchVirtue("PuissantAbility", "PuissantAbility", VirtueType.General, VirtueMajorMinor.MINOR);
-        public static ArchVirtue Relic = new ArchVirtue("Relic", "Relic", VirtueType.General, VirtueMajorMinor.MINOR);
-        public static ArchVirtue ReservesofStrength = new ArchVirtue("ReservesofStrength", "ReservesofStrength", VirtueType.General, VirtueMajorMinor.MINOR);
-        public static ArchVirtue SelfConfident = new ArchVirtue("Self-Confident", "Self-Confident", VirtueType.General, VirtueMajorMinor.MINOR);
-        public static ArchVirtue SharpEars = new ArchVirtue("SharpEars", "SharpEars", VirtueType.General, VirtueMajorMinor.MINOR);
-        public static ArchVirtue SocialContacts = new ArchVirtue("SocialContacts", "SocialContacts", VirtueType.General, VirtueMajorMinor.MINOR);
-        public static ArchVirtue StrongWilled = new ArchVirtue("Strong-Willed", "Strong-Willed", VirtueType.General, VirtueMajorMinor.MINOR);
-        public static ArchVirtue StudentofRealm = new ArchVirtue("Studentof(Realm)", "Studentof(Realm)", VirtueType.General, VirtueMajorMinor.MINOR);
-        public static ArchVirtue TemporalInfluence = new ArchVirtue("TemporalInfluence", "TemporalInfluence", VirtueType.General, VirtueMajorMinor.MINOR);
-        public static ArchVirtue Tough = new ArchVirtue("Tough", "Tough", VirtueType.General, VirtueMajorMinor.MINOR);
-        public static ArchVirtue TroupeUpbringing = new ArchVirtue("TroupeUpbringing", "TroupeUpbringing", VirtueType.General, VirtueMajorMinor.MINOR);
-        public static ArchVirtue TrueLovePC = new ArchVirtue("TrueLove(PC)", "TrueLove(PC)", VirtueType.General, VirtueMajorMinor.MINOR);
-        public static ArchVirtue Unaging = new ArchVirtue("Unaging", "Unaging", VirtueType.General, VirtueMajorMinor.MINOR);
-        public static ArchVirtue VenusBlessing = new ArchVirtue("Venus’Blessing", "Venus’Blessing", VirtueType.General, VirtueMajorMinor.MINOR);
-        public static ArchVirtue Warrior = new ArchVirtue("Warrior", "Warrior", VirtueType.General, VirtueMajorMinor.MINOR);
-        public static ArchVirtue WellTraveled = new ArchVirtue("Well-Traveled", "Well-Traveled", VirtueType.General, VirtueMajorMinor.MINOR);
+        private static ArchVirtue AffinitywithAbility = new ArchVirtue("AffinitywithAbility", "AffinitywithAbility", VirtueType.General, VirtueMajorMinor.MINOR);
+        private static ArchVirtue AptStudent = new ArchVirtue("AptStudent", "AptStudent", VirtueType.General, VirtueMajorMinor.MINOR);
+        private static ArchVirtue ArcaneLore = new ArchVirtue("ArcaneLore", "ArcaneLore", VirtueType.General, VirtueMajorMinor.MINOR);
+        private static ArchVirtue Berserk = new ArchVirtue("Berserk", "Berserk", VirtueType.General, VirtueMajorMinor.MINOR);
+        private static ArchVirtue BookLearner = new ArchVirtue("BookLearner", "BookLearner", VirtueType.General, VirtueMajorMinor.MINOR);
+        private static ArchVirtue CautiouswithAbility = new ArchVirtue("CautiouswithAbility", "CautiouswithAbility", VirtueType.General, VirtueMajorMinor.MINOR);
+        private static ArchVirtue ClearThinker = new ArchVirtue("ClearThinker", "ClearThinker", VirtueType.General, VirtueMajorMinor.MINOR);
+        private static ArchVirtue CommonSense = new ArchVirtue("CommonSense", "CommonSense", VirtueType.General, VirtueMajorMinor.MINOR);
+        private static ArchVirtue Educated = new ArchVirtue("Educated", "Educated", VirtueType.General, VirtueMajorMinor.MINOR);
+        private static ArchVirtue EnduringConstitution = new ArchVirtue("EnduringConstitution", "EnduringConstitution", VirtueType.General, VirtueMajorMinor.MINOR);
+        private static ArchVirtue FaerieBlood = new ArchVirtue("FaerieBlood", "FaerieBlood", VirtueType.General, VirtueMajorMinor.MINOR);
+        private static ArchVirtue Famous = new ArchVirtue("Famous", "Famous", VirtueType.General, VirtueMajorMinor.MINOR);
+        private static ArchVirtue FreeExpression = new ArchVirtue("FreeExpression", "FreeExpression", VirtueType.General, VirtueMajorMinor.MINOR);
+        private static ArchVirtue GoodTeacher = new ArchVirtue("GoodTeacher", "GoodTeacher", VirtueType.General, VirtueMajorMinor.MINOR);
+        private static ArchVirtue Gossip = new ArchVirtue("Gossip", "Gossip", VirtueType.General, VirtueMajorMinor.MINOR);
+        private static ArchVirtue ImprovedCharacteristics = new ArchVirtue("ImprovedCharacteristics", "ImprovedCharacteristics", VirtueType.General, VirtueMajorMinor.MINOR);
+        private static ArchVirtue Inspirational = new ArchVirtue("Inspirational", "Inspirational", VirtueType.General, VirtueMajorMinor.MINOR);
+        private static ArchVirtue Intuition = new ArchVirtue("Intuition", "Intuition", VirtueType.General, VirtueMajorMinor.MINOR);
+        private static ArchVirtue KeenVision = new ArchVirtue("KeenVision", "KeenVision", VirtueType.General, VirtueMajorMinor.MINOR);
+        private static ArchVirtue Large = new ArchVirtue("Large", "Large", VirtueType.General, VirtueMajorMinor.MINOR);
+        private static ArchVirtue LatentMagicalAbility = new ArchVirtue("LatentMagicalAbility", "LatentMagicalAbility", VirtueType.General, VirtueMajorMinor.MINOR);
+        private static ArchVirtue LearnAbilityfromMistakes = new ArchVirtue("Learn(Ability)fromMistakes", "Learn(Ability)fromMistakes", VirtueType.General, VirtueMajorMinor.MINOR);
+        private static ArchVirtue LightTouch = new ArchVirtue("LightTouch", "LightTouch", VirtueType.General, VirtueMajorMinor.MINOR);
+        private static ArchVirtue LightningReflexes = new ArchVirtue("LightningReflexes", "LightningReflexes", VirtueType.General, VirtueMajorMinor.MINOR);
+        private static ArchVirtue LongWinded = new ArchVirtue("Long-Winded", "Long-Winded", VirtueType.General, VirtueMajorMinor.MINOR);
+        private static ArchVirtue Luck = new ArchVirtue("Luck", "Luck", VirtueType.General, VirtueMajorMinor.MINOR);
+        private static ArchVirtue RapidConvalescence = new ArchVirtue("RapidConvalescence", "RapidConvalescence", VirtueType.General, VirtueMajorMinor.MINOR);
+        private static ArchVirtue PerfectBalance = new ArchVirtue("PerfectBalance", "PerfectBalance", VirtueType.General, VirtueMajorMinor.MINOR);
+        private static ArchVirtue PiercingGaze = new ArchVirtue("PiercingGaze", "PiercingGaze", VirtueType.General, VirtueMajorMinor.MINOR);
+        private static ArchVirtue PrivilegedUpbringing = new ArchVirtue("PrivilegedUpbringing", "PrivilegedUpbringing", VirtueType.General, VirtueMajorMinor.MINOR);
+        private static ArchVirtue Protection = new ArchVirtue("Protection", "Protection", VirtueType.General, VirtueMajorMinor.MINOR);
+        private static ArchVirtue PuissantAbility = new ArchVirtue("PuissantAbility", "PuissantAbility", VirtueType.General, VirtueMajorMinor.MINOR);
+        private static ArchVirtue Relic = new ArchVirtue("Relic", "Relic", VirtueType.General, VirtueMajorMinor.MINOR);
+        private static ArchVirtue ReservesofStrength = new ArchVirtue("ReservesofStrength", "ReservesofStrength", VirtueType.General, VirtueMajorMinor.MINOR);
+        private static ArchVirtue SelfConfident = new ArchVirtue("Self-Confident", "Self-Confident", VirtueType.General, VirtueMajorMinor.MINOR);
+        private static ArchVirtue SharpEars = new ArchVirtue("SharpEars", "SharpEars", VirtueType.General, VirtueMajorMinor.MINOR);
+        private static ArchVirtue SocialContacts = new ArchVirtue("SocialContacts", "SocialContacts", VirtueType.General, VirtueMajorMinor.MINOR);
+        private static ArchVirtue StrongWilled = new ArchVirtue("Strong-Willed", "Strong-Willed", VirtueType.General, VirtueMajorMinor.MINOR);
+        private static ArchVirtue StudentofRealm = new ArchVirtue("Studentof(Realm)", "Studentof(Realm)", VirtueType.General, VirtueMajorMinor.MINOR);
+        private static ArchVirtue TemporalInfluence = new ArchVirtue("TemporalInfluence", "TemporalInfluence", VirtueType.General, VirtueMajorMinor.MINOR);
+        private static ArchVirtue Tough = new ArchVirtue("Tough", "Tough", VirtueType.General, VirtueMajorMinor.MINOR);
+        private static ArchVirtue TroupeUpbringing = new ArchVirtue("TroupeUpbringing", "TroupeUpbringing", VirtueType.General, VirtueMajorMinor.MINOR);
+        private static ArchVirtue TrueLovePC = new ArchVirtue("TrueLove(PC)", "TrueLove(PC)", VirtueType.General, VirtueMajorMinor.MINOR);
+        private static ArchVirtue Unaging = new ArchVirtue("Unaging", "Unaging", VirtueType.General, VirtueMajorMinor.MINOR);
+        private static ArchVirtue VenusBlessing = new ArchVirtue("Venus’Blessing", "Venus’Blessing", VirtueType.General, VirtueMajorMinor.MINOR);
+        private static ArchVirtue Warrior = new ArchVirtue("Warrior", "Warrior", VirtueType.General, VirtueMajorMinor.MINOR);
+        private static ArchVirtue WellTraveled = new ArchVirtue("Well-Traveled", "Well-Traveled", VirtueType.General, VirtueMajorMinor.MINOR);
         
         // Social Free
-        public static ArchVirtue Covenfolk = new ArchVirtue("Covenfolk", "Covenfolk", VirtueType.Social, VirtueMajorMinor.FREE);
-        public static ArchVirtue Craftsman = new ArchVirtue("Craftsman", "Craftsman", VirtueType.Social, VirtueMajorMinor.FREE);
-        public static ArchVirtue HermeticMagus = new ArchVirtue("HermeticMagus", "HermeticMagus", VirtueType.Social, VirtueMajorMinor.FREE);
-        public static ArchVirtue Merchant = new ArchVirtue("Merchant", "Merchant", VirtueType.Social, VirtueMajorMinor.FREE);
-        public static ArchVirtue Peasant = new ArchVirtue("Peasant", "Peasant", VirtueType.Social, VirtueMajorMinor.FREE);
-        public static ArchVirtue Wanderer = new ArchVirtue("Wanderer", "Wanderer", VirtueType.Social, VirtueMajorMinor.FREE);
+        private static ArchVirtue Covenfolk = new ArchVirtue("Covenfolk", "Covenfolk", VirtueType.Social, VirtueMajorMinor.FREE);
+        private static ArchVirtue Craftsman = new ArchVirtue("Craftsman", "Craftsman", VirtueType.Social, VirtueMajorMinor.FREE);
+        private static ArchVirtue HermeticMagus = new ArchVirtue("HermeticMagus", "HermeticMagus", VirtueType.Social, VirtueMajorMinor.FREE);
+        private static ArchVirtue Merchant = new ArchVirtue("Merchant", "Merchant", VirtueType.Social, VirtueMajorMinor.FREE);
+        private static ArchVirtue Peasant = new ArchVirtue("Peasant", "Peasant", VirtueType.Social, VirtueMajorMinor.FREE);
+        private static ArchVirtue Wanderer = new ArchVirtue("Wanderer", "Wanderer", VirtueType.Social, VirtueMajorMinor.FREE);
+        #endregion
+
+        #region Populating the NameToArchVirtue Dictionary
+        private static void PopulateVirtueDictionary()
+        {
+            NameToArchVirtue.Add("TheGift", TheGift);
+
+            // Hermetic Major
+            NameToArchVirtue.Add("DiedneMagic", DiedneMagic);
+            NameToArchVirtue.Add("ElementalMagic", ElementalMagic);
+            NameToArchVirtue.Add("FlawlessMagic", FlawlessMagic);
+            NameToArchVirtue.Add("FlexibleFormulaicMagic", FlexibleFormulaicMagic);
+            NameToArchVirtue.Add("GentleGift", GentleGift);
+            NameToArchVirtue.Add("Life-LinkedSpontaneousMagic", LifeLinkedSpontaneousMagic);
+            NameToArchVirtue.Add("MajorMagicalFocus", MajorMagicalFocus);
+            NameToArchVirtue.Add("MercurianMagic", MercurianMagic);
+            NameToArchVirtue.Add("MythicBlood", MythicBlood);
+            NameToArchVirtue.Add("SecondaryInsight", SecondaryInsight);
+
+            // Supernatural Major
+            NameToArchVirtue.Add("Entrancement", Entrancement);
+            NameToArchVirtue.Add("GreaterImmunity", GreaterImmunity);
+            NameToArchVirtue.Add("GreaterPurifyingTouch", GreaterPurifyingTouch);
+            NameToArchVirtue.Add("Shapeshifter", Shapeshifter);
+            NameToArchVirtue.Add("StrongFaerieBlood", StrongFaerieBlood);
+
+            // Social Status Major
+            NameToArchVirtue.Add("LandedNoble", LandedNoble);
+            NameToArchVirtue.Add("MagisterinArtibus", MagisterinArtibus);
+            NameToArchVirtue.Add("Redcap", Redcap);
+
+            // General Major
+            NameToArchVirtue.Add("DeathProphecy", DeathProphecy);
+            NameToArchVirtue.Add("GhostlyWarder", GhostlyWarder);
+            NameToArchVirtue.Add("GiantBlood", GiantBlood);
+            NameToArchVirtue.Add("GuardianAngel", GuardianAngel);
+            NameToArchVirtue.Add("TrueFaith", TrueFaith);
+            NameToArchVirtue.Add("Waysofthe(Land)", WaysoftheLand);
+            NameToArchVirtue.Add("Wealthy", Wealthy);
+
+            // Hermetic Minor
+            NameToArchVirtue.Add("AdeptLaboratoryStudent", AdeptLaboratoryStudent);
+            NameToArchVirtue.Add("AffinitywithArt", AffinitywithArt);
+            NameToArchVirtue.Add("CautiousSorcerer", CautiousSorcerer);
+            NameToArchVirtue.Add("CyclicMagic(positive)", CyclicMagicpositive);
+            NameToArchVirtue.Add("DeftForm", DeftForm);
+            NameToArchVirtue.Add("EnduringMagic", EnduringMagic);
+            NameToArchVirtue.Add("TheEnigma", TheEnigma);
+            NameToArchVirtue.Add("FaerieMagic", FaerieMagic);
+            NameToArchVirtue.Add("FastCaster", FastCaster);
+            NameToArchVirtue.Add("FreeStudy", FreeStudy);
+            NameToArchVirtue.Add("HarnessedMagic", HarnessedMagic);
+            NameToArchVirtue.Add("Heartbeast", Heartbeast);
+            NameToArchVirtue.Add("HermeticPrestige", HermeticPrestige);
+            NameToArchVirtue.Add("InoffensivetoAnimals", InoffensivetoAnimals);
+            NameToArchVirtue.Add("InventiveGenius", InventiveGenius);
+            NameToArchVirtue.Add("LifeBoost", LifeBoost);
+            NameToArchVirtue.Add("MinorMagicalFocus", MinorMagicalFocus);
+            NameToArchVirtue.Add("MagicalMemory", MagicalMemory);
+            NameToArchVirtue.Add("MasteredSpells", MasteredSpells);
+            NameToArchVirtue.Add("MethodCaster", MethodCaster);
+            NameToArchVirtue.Add("PersonalVisSource", PersonalVisSource);
+            NameToArchVirtue.Add("PuissantArt", PuissantArt);
+            NameToArchVirtue.Add("QuietMagic", QuietMagic);
+            NameToArchVirtue.Add("SideEffect", SideEffect);
+            NameToArchVirtue.Add("SkilledParens", SkilledParens);
+            NameToArchVirtue.Add("SpecialCircumstances", SpecialCircumstances);
+            NameToArchVirtue.Add("StudyBonus", StudyBonus);
+            NameToArchVirtue.Add("SubtleMagic", SubtleMagic);
+            NameToArchVirtue.Add("VerditiusMagic", VerditiusMagic);
+
+            // Supernatural Minor
+            NameToArchVirtue.Add("AnimalKen", AnimalKen);
+            NameToArchVirtue.Add("Dowsing", Dowsing);
+            NameToArchVirtue.Add("EnchantingMusic", EnchantingMusic);
+            NameToArchVirtue.Add("LesserImmunity", LesserImmunity);
+            NameToArchVirtue.Add("LesserPurifyingTouch", LesserPurifyingTouch);
+            NameToArchVirtue.Add("MagicSensitivity", MagicSensitivity);
+            NameToArchVirtue.Add("Premonitions", Premonitions);
+            NameToArchVirtue.Add("SecondSight", SecondSight);
+            NameToArchVirtue.Add("SenseHolinessandUnholiness", SenseHolinessandUnholiness);
+            NameToArchVirtue.Add("Skinchanger", Skinchanger);
+            NameToArchVirtue.Add("WildernessSense", WildernessSense);
+
+            // Social Minor
+            NameToArchVirtue.Add("Clerk", Clerk);
+            NameToArchVirtue.Add("Custos", Custos);
+            NameToArchVirtue.Add("FailedApprentice", FailedApprentice);
+            NameToArchVirtue.Add("Gentleman/woman", Gentlemanwoman);
+            NameToArchVirtue.Add("Knight", Knight);
+            NameToArchVirtue.Add("MendicantFriar", MendicantFriar);
+            NameToArchVirtue.Add("MercenaryCaptain", MercenaryCaptain);
+            NameToArchVirtue.Add("Priest", Priest);
+            NameToArchVirtue.Add("WiseOne", WiseOne);
+
+            // General Minor
+            NameToArchVirtue.Add("AffinitywithAbility", AffinitywithAbility);
+            NameToArchVirtue.Add("AptStudent", AptStudent);
+            NameToArchVirtue.Add("ArcaneLore", ArcaneLore);
+            NameToArchVirtue.Add("Berserk", Berserk);
+            NameToArchVirtue.Add("BookLearner", BookLearner);
+            NameToArchVirtue.Add("CautiouswithAbility", CautiouswithAbility);
+            NameToArchVirtue.Add("ClearThinker", ClearThinker);
+            NameToArchVirtue.Add("CommonSense", CommonSense);
+            NameToArchVirtue.Add("Educated", Educated);
+            NameToArchVirtue.Add("EnduringConstitution", EnduringConstitution);
+            NameToArchVirtue.Add("FaerieBlood", FaerieBlood);
+            NameToArchVirtue.Add("Famous", Famous);
+            NameToArchVirtue.Add("FreeExpression", FreeExpression);
+            NameToArchVirtue.Add("GoodTeacher", GoodTeacher);
+            NameToArchVirtue.Add("Gossip", Gossip);
+            NameToArchVirtue.Add("ImprovedCharacteristics", ImprovedCharacteristics);
+            NameToArchVirtue.Add("Inspirational", Inspirational);
+            NameToArchVirtue.Add("Intuition", Intuition);
+            NameToArchVirtue.Add("KeenVision", KeenVision);
+            NameToArchVirtue.Add("Large", Large);
+            NameToArchVirtue.Add("LatentMagicalAbility", LatentMagicalAbility);
+            NameToArchVirtue.Add("Learn(Ability)fromMistakes", LearnAbilityfromMistakes);
+            NameToArchVirtue.Add("LightTouch", LightTouch);
+            NameToArchVirtue.Add("LightningReflexes", LightningReflexes);
+            NameToArchVirtue.Add("Long-Winded", LongWinded);
+            NameToArchVirtue.Add("Luck", Luck);
+            NameToArchVirtue.Add("RapidConvalescence", RapidConvalescence);
+            NameToArchVirtue.Add("PerfectBalance", PerfectBalance);
+            NameToArchVirtue.Add("PiercingGaze", PiercingGaze);
+            NameToArchVirtue.Add("PrivilegedUpbringing", PrivilegedUpbringing);
+            NameToArchVirtue.Add("Protection", Protection);
+            NameToArchVirtue.Add("PuissantAbility", PuissantAbility);
+            NameToArchVirtue.Add("Relic", Relic);
+            NameToArchVirtue.Add("ReservesofStrength", ReservesofStrength);
+            NameToArchVirtue.Add("Self-Confident", SelfConfident);
+            NameToArchVirtue.Add("SharpEars", SharpEars);
+            NameToArchVirtue.Add("SocialContacts", SocialContacts);
+            NameToArchVirtue.Add("Strong-Willed", StrongWilled);
+            NameToArchVirtue.Add("Studentof(Realm)", StudentofRealm);
+            NameToArchVirtue.Add("TemporalInfluence", TemporalInfluence);
+            NameToArchVirtue.Add("Tough", Tough);
+            NameToArchVirtue.Add("TroupeUpbringing", TroupeUpbringing);
+            NameToArchVirtue.Add("TrueLove(PC)", TrueLovePC);
+            NameToArchVirtue.Add("Unaging", Unaging);
+            NameToArchVirtue.Add("VenusBlessing", VenusBlessing);
+            NameToArchVirtue.Add("Warrior", Warrior);
+            NameToArchVirtue.Add("Well-Traveled", WellTraveled);
+
+            // Social Free
+            NameToArchVirtue.Add("Covenfolk", Covenfolk);
+            NameToArchVirtue.Add("Craftsman", Craftsman);
+            NameToArchVirtue.Add("HermeticMagus", HermeticMagus);
+            NameToArchVirtue.Add("Merchant", Merchant);
+            NameToArchVirtue.Add("Peasant", Peasant);
+            NameToArchVirtue.Add("Wanderer", Wanderer);
+        }
+
+        #endregion
     }
 }

--- a/WizardMakerTestbed/Models/Virtues/ArchVirtue.cs
+++ b/WizardMakerTestbed/Models/Virtues/ArchVirtue.cs
@@ -1,0 +1,208 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace WizardMakerPrototype.Models.Virtues
+{
+
+    public class VirtueType
+    {
+        public static List<VirtueType> Types = new List<VirtueType>();
+
+        public string Abbreviation { get; private set; }
+        public string Name { get; private set; }
+
+
+        // This is only public so that it can be available for serialization
+        public VirtueType(string abbrev, string name)
+        {
+            this.Abbreviation = abbrev;
+            this.Name = name;
+        }
+
+        public static VirtueType Hermetic = new VirtueType("Hermetic", "Hermetic");
+        public static VirtueType Supernatural = new VirtueType("Supernatural", "Supernatural");
+        public static VirtueType Social = new VirtueType("Social", "Social");
+        public static VirtueType General = new VirtueType("General", "General");
+
+        static VirtueType()
+        {
+            Types.Add(Hermetic);
+            Types.Add(General);
+            Types.Add(Social);
+            Types.Add(Supernatural);
+        }
+    }
+
+    public enum VirtueMajorMinor { MAJOR = 3, MINOR = 1, FREE = 0}
+    public class ArchVirtue
+    {
+        public string Name;
+        public string Description;
+        public VirtueType Type;
+        public VirtueMajorMinor MajorMinor;
+
+        public ArchVirtue(string name, string description, VirtueType type, VirtueMajorMinor majorMinor)
+        {
+            Name = name;
+            Type = type;
+            Description = description;
+            MajorMinor = majorMinor;
+        }
+
+        // TODO: In future, rather than a hard-coded list,
+        // the program will offer the means to declare a new Virtue at runtime.
+        // 
+        // This will be especially needful, when considering "wildcard" Virtues which describe a list of many virtues, such as:
+        //  Way of the (Land)
+
+        public static ArchVirtue TheGift = new ArchVirtue("TheGift", "TheGift", VirtueType.Hermetic, VirtueMajorMinor.FREE);
+        
+        // Hermetic Major
+        public static ArchVirtue DiedneMagic = new ArchVirtue("DiedneMagic", "DiedneMagic", VirtueType.Hermetic, VirtueMajorMinor.MAJOR);
+        public static ArchVirtue ElementalMagic = new ArchVirtue("ElementalMagic", "ElementalMagic", VirtueType.Hermetic, VirtueMajorMinor.MAJOR);
+        public static ArchVirtue FlawlessMagic = new ArchVirtue("FlawlessMagic", "FlawlessMagic", VirtueType.Hermetic, VirtueMajorMinor.MAJOR);
+        public static ArchVirtue FlexibleFormulaicMagic = new ArchVirtue("FlexibleFormulaicMagic", "FlexibleFormulaicMagic", VirtueType.Hermetic, VirtueMajorMinor.MAJOR);
+        public static ArchVirtue GentleGift = new ArchVirtue("GentleGift", "GentleGift", VirtueType.Hermetic, VirtueMajorMinor.MAJOR);
+        public static ArchVirtue LifeLinkedSpontaneousMagic = new ArchVirtue("Life-LinkedSpontaneousMagic", "Life-LinkedSpontaneousMagic", VirtueType.Hermetic, VirtueMajorMinor.MAJOR);
+        public static ArchVirtue MajorMagicalFocus = new ArchVirtue("MajorMagicalFocus", "MajorMagicalFocus", VirtueType.Hermetic, VirtueMajorMinor.MAJOR);
+        public static ArchVirtue MercurianMagic = new ArchVirtue("MercurianMagic", "MercurianMagic", VirtueType.Hermetic, VirtueMajorMinor.MAJOR);
+        public static ArchVirtue MythicBlood = new ArchVirtue("MythicBlood", "MythicBlood", VirtueType.Hermetic, VirtueMajorMinor.MAJOR);
+        public static ArchVirtue SecondaryInsight = new ArchVirtue("SecondaryInsight", "SecondaryInsight", VirtueType.Hermetic, VirtueMajorMinor.MAJOR);
+        
+        // Supernatural Major
+        public static ArchVirtue Entrancement = new ArchVirtue("Entrancement", "Entrancement", VirtueType.Supernatural, VirtueMajorMinor.MAJOR);
+        public static ArchVirtue GreaterImmunity = new ArchVirtue("GreaterImmunity", "GreaterImmunity", VirtueType.Supernatural, VirtueMajorMinor.MAJOR);
+        public static ArchVirtue GreaterPurifyingTouch = new ArchVirtue("GreaterPurifyingTouch", "GreaterPurifyingTouch", VirtueType.Supernatural, VirtueMajorMinor.MAJOR);
+        public static ArchVirtue Shapeshifter = new ArchVirtue("Shapeshifter", "Shapeshifter", VirtueType.Supernatural, VirtueMajorMinor.MAJOR);
+        public static ArchVirtue StrongFaerieBlood = new ArchVirtue("StrongFaerieBlood", "StrongFaerieBlood", VirtueType.Supernatural, VirtueMajorMinor.MAJOR);
+        
+        // Social Status Major
+        public static ArchVirtue LandedNoble = new ArchVirtue("LandedNoble", "LandedNoble", VirtueType.Social, VirtueMajorMinor.MAJOR);
+        public static ArchVirtue MagisterinArtibus = new ArchVirtue("MagisterinArtibus", "MagisterinArtibus", VirtueType.Social, VirtueMajorMinor.MAJOR);
+        public static ArchVirtue Redcap = new ArchVirtue("Redcap", "Redcap", VirtueType.Social, VirtueMajorMinor.MAJOR);
+        
+        // General Major
+        public static ArchVirtue DeathProphecy = new ArchVirtue("DeathProphecy", "DeathProphecy", VirtueType.General, VirtueMajorMinor.MAJOR);
+        public static ArchVirtue GhostlyWarder = new ArchVirtue("GhostlyWarder", "GhostlyWarder", VirtueType.General, VirtueMajorMinor.MAJOR);
+        public static ArchVirtue GiantBlood = new ArchVirtue("GiantBlood", "GiantBlood", VirtueType.General, VirtueMajorMinor.MAJOR);
+        public static ArchVirtue GuardianAngel = new ArchVirtue("GuardianAngel", "GuardianAngel", VirtueType.General, VirtueMajorMinor.MAJOR);
+        public static ArchVirtue TrueFaith = new ArchVirtue("TrueFaith", "TrueFaith", VirtueType.General, VirtueMajorMinor.MAJOR);
+        public static ArchVirtue WaysoftheLand = new ArchVirtue("Waysofthe(Land)", "Waysofthe(Land)", VirtueType.General, VirtueMajorMinor.MAJOR);
+        public static ArchVirtue Wealthy = new ArchVirtue("Wealthy", "Wealthy", VirtueType.General, VirtueMajorMinor.MAJOR);
+        
+        // Hermetic Minor
+        public static ArchVirtue AdeptLaboratoryStudent = new ArchVirtue("AdeptLaboratoryStudent", "AdeptLaboratoryStudent", VirtueType.Hermetic, VirtueMajorMinor.MINOR);
+        public static ArchVirtue AffinitywithArt = new ArchVirtue("AffinitywithArt", "AffinitywithArt", VirtueType.Hermetic, VirtueMajorMinor.MINOR);
+        public static ArchVirtue CautiousSorcerer = new ArchVirtue("CautiousSorcerer", "CautiousSorcerer", VirtueType.Hermetic, VirtueMajorMinor.MINOR);
+        public static ArchVirtue CyclicMagicpositive = new ArchVirtue("CyclicMagic(positive)", "CyclicMagic(positive)", VirtueType.Hermetic, VirtueMajorMinor.MINOR);
+        public static ArchVirtue DeftForm = new ArchVirtue("DeftForm", "DeftForm", VirtueType.Hermetic, VirtueMajorMinor.MINOR);
+        public static ArchVirtue EnduringMagic = new ArchVirtue("EnduringMagic", "EnduringMagic", VirtueType.Hermetic, VirtueMajorMinor.MINOR);
+        public static ArchVirtue TheEnigma = new ArchVirtue("TheEnigma", "TheEnigma", VirtueType.Hermetic, VirtueMajorMinor.MINOR);
+        public static ArchVirtue FaerieMagic = new ArchVirtue("FaerieMagic", "FaerieMagic", VirtueType.Hermetic, VirtueMajorMinor.MINOR);
+        public static ArchVirtue FastCaster = new ArchVirtue("FastCaster", "FastCaster", VirtueType.Hermetic, VirtueMajorMinor.MINOR);
+        public static ArchVirtue FreeStudy = new ArchVirtue("FreeStudy", "FreeStudy", VirtueType.Hermetic, VirtueMajorMinor.MINOR);
+        public static ArchVirtue HarnessedMagic = new ArchVirtue("HarnessedMagic", "HarnessedMagic", VirtueType.Hermetic, VirtueMajorMinor.MINOR);
+        public static ArchVirtue Heartbeast = new ArchVirtue("Heartbeast", "Heartbeast", VirtueType.Hermetic, VirtueMajorMinor.MINOR);
+        public static ArchVirtue HermeticPrestige = new ArchVirtue("HermeticPrestige", "HermeticPrestige", VirtueType.Hermetic, VirtueMajorMinor.MINOR);
+        public static ArchVirtue InoffensivetoAnimals = new ArchVirtue("InoffensivetoAnimals", "InoffensivetoAnimals", VirtueType.Hermetic, VirtueMajorMinor.MINOR);
+        public static ArchVirtue InventiveGenius = new ArchVirtue("InventiveGenius", "InventiveGenius", VirtueType.Hermetic, VirtueMajorMinor.MINOR);
+        public static ArchVirtue LifeBoost = new ArchVirtue("LifeBoost", "LifeBoost", VirtueType.Hermetic, VirtueMajorMinor.MINOR);
+        public static ArchVirtue MinorMagicalFocus = new ArchVirtue("MinorMagicalFocus", "MinorMagicalFocus", VirtueType.Hermetic, VirtueMajorMinor.MINOR);
+        public static ArchVirtue MagicalMemory = new ArchVirtue("MagicalMemory", "MagicalMemory", VirtueType.Hermetic, VirtueMajorMinor.MINOR);
+        public static ArchVirtue MasteredSpells = new ArchVirtue("MasteredSpells", "MasteredSpells", VirtueType.Hermetic, VirtueMajorMinor.MINOR);
+        public static ArchVirtue MethodCaster = new ArchVirtue("MethodCaster", "MethodCaster", VirtueType.Hermetic, VirtueMajorMinor.MINOR);
+        public static ArchVirtue PersonalVisSource = new ArchVirtue("PersonalVisSource", "PersonalVisSource", VirtueType.Hermetic, VirtueMajorMinor.MINOR);
+        public static ArchVirtue PuissantArt = new ArchVirtue("PuissantArt", "PuissantArt", VirtueType.Hermetic, VirtueMajorMinor.MINOR);
+        public static ArchVirtue QuietMagic = new ArchVirtue("QuietMagic", "QuietMagic", VirtueType.Hermetic, VirtueMajorMinor.MINOR);
+        public static ArchVirtue SideEffect = new ArchVirtue("SideEffect", "SideEffect", VirtueType.Hermetic, VirtueMajorMinor.MINOR);
+        public static ArchVirtue SkilledParens = new ArchVirtue("SkilledParens", "SkilledParens", VirtueType.Hermetic, VirtueMajorMinor.MINOR);
+        public static ArchVirtue SpecialCircumstances = new ArchVirtue("SpecialCircumstances", "SpecialCircumstances", VirtueType.Hermetic, VirtueMajorMinor.MINOR);
+        public static ArchVirtue StudyBonus = new ArchVirtue("StudyBonus", "StudyBonus", VirtueType.Hermetic, VirtueMajorMinor.MINOR);
+        public static ArchVirtue SubtleMagic = new ArchVirtue("SubtleMagic", "SubtleMagic", VirtueType.Hermetic, VirtueMajorMinor.MINOR);
+        public static ArchVirtue VerditiusMagic = new ArchVirtue("VerditiusMagic", "VerditiusMagic", VirtueType.Hermetic, VirtueMajorMinor.MINOR);
+        
+        // Supernatural Minor
+        public static ArchVirtue AnimalKen = new ArchVirtue("AnimalKen", "AnimalKen", VirtueType.Supernatural, VirtueMajorMinor.MINOR);
+        public static ArchVirtue Dowsing = new ArchVirtue("Dowsing", "Dowsing", VirtueType.Supernatural, VirtueMajorMinor.MINOR);
+        public static ArchVirtue EnchantingMusic = new ArchVirtue("EnchantingMusic", "EnchantingMusic", VirtueType.Supernatural, VirtueMajorMinor.MINOR);
+        public static ArchVirtue LesserImmunity = new ArchVirtue("LesserImmunity", "LesserImmunity", VirtueType.Supernatural, VirtueMajorMinor.MINOR);
+        public static ArchVirtue LesserPurifyingTouch = new ArchVirtue("LesserPurifyingTouch", "LesserPurifyingTouch", VirtueType.Supernatural, VirtueMajorMinor.MINOR);
+        public static ArchVirtue MagicSensitivity = new ArchVirtue("MagicSensitivity", "MagicSensitivity", VirtueType.Supernatural, VirtueMajorMinor.MINOR);
+        public static ArchVirtue Premonitions = new ArchVirtue("Premonitions", "Premonitions", VirtueType.Supernatural, VirtueMajorMinor.MINOR);
+        public static ArchVirtue SecondSight = new ArchVirtue("SecondSight", "SecondSight", VirtueType.Supernatural, VirtueMajorMinor.MINOR);
+        public static ArchVirtue SenseHolinessandUnholiness = new ArchVirtue("SenseHolinessandUnholiness", "SenseHolinessandUnholiness", VirtueType.Supernatural, VirtueMajorMinor.MINOR);
+        public static ArchVirtue Skinchanger = new ArchVirtue("Skinchanger", "Skinchanger", VirtueType.Supernatural, VirtueMajorMinor.MINOR);
+        public static ArchVirtue WildernessSense = new ArchVirtue("WildernessSense", "WildernessSense", VirtueType.Supernatural, VirtueMajorMinor.MINOR);
+        
+        // Social Minor
+        public static ArchVirtue Clerk = new ArchVirtue("Clerk", "Clerk", VirtueType.Social, VirtueMajorMinor.MINOR);
+        public static ArchVirtue Custos = new ArchVirtue("Custos", "Custos", VirtueType.Social, VirtueMajorMinor.MINOR);
+        public static ArchVirtue FailedApprentice = new ArchVirtue("FailedApprentice", "FailedApprentice", VirtueType.Social, VirtueMajorMinor.MINOR);
+        public static ArchVirtue Gentlemanwoman = new ArchVirtue("Gentleman/woman", "Gentleman/woman", VirtueType.Social, VirtueMajorMinor.MINOR);
+        public static ArchVirtue Knight = new ArchVirtue("Knight", "Knight", VirtueType.Social, VirtueMajorMinor.MINOR);
+        public static ArchVirtue MendicantFriar = new ArchVirtue("MendicantFriar", "MendicantFriar", VirtueType.Social, VirtueMajorMinor.MINOR);
+        public static ArchVirtue MercenaryCaptain = new ArchVirtue("MercenaryCaptain", "MercenaryCaptain", VirtueType.Social, VirtueMajorMinor.MINOR);
+        public static ArchVirtue Priest = new ArchVirtue("Priest", "Priest", VirtueType.Social, VirtueMajorMinor.MINOR);
+        public static ArchVirtue WiseOne = new ArchVirtue("WiseOne", "WiseOne", VirtueType.Social, VirtueMajorMinor.MINOR);
+        
+        // General Minor
+        public static ArchVirtue AffinitywithAbility = new ArchVirtue("AffinitywithAbility", "AffinitywithAbility", VirtueType.General, VirtueMajorMinor.MINOR);
+        public static ArchVirtue AptStudent = new ArchVirtue("AptStudent", "AptStudent", VirtueType.General, VirtueMajorMinor.MINOR);
+        public static ArchVirtue ArcaneLore = new ArchVirtue("ArcaneLore", "ArcaneLore", VirtueType.General, VirtueMajorMinor.MINOR);
+        public static ArchVirtue Berserk = new ArchVirtue("Berserk", "Berserk", VirtueType.General, VirtueMajorMinor.MINOR);
+        public static ArchVirtue BookLearner = new ArchVirtue("BookLearner", "BookLearner", VirtueType.General, VirtueMajorMinor.MINOR);
+        public static ArchVirtue CautiouswithAbility = new ArchVirtue("CautiouswithAbility", "CautiouswithAbility", VirtueType.General, VirtueMajorMinor.MINOR);
+        public static ArchVirtue ClearThinker = new ArchVirtue("ClearThinker", "ClearThinker", VirtueType.General, VirtueMajorMinor.MINOR);
+        public static ArchVirtue CommonSense = new ArchVirtue("CommonSense", "CommonSense", VirtueType.General, VirtueMajorMinor.MINOR);
+        public static ArchVirtue Educated = new ArchVirtue("Educated", "Educated", VirtueType.General, VirtueMajorMinor.MINOR);
+        public static ArchVirtue EnduringConstitution = new ArchVirtue("EnduringConstitution", "EnduringConstitution", VirtueType.General, VirtueMajorMinor.MINOR);
+        public static ArchVirtue FaerieBlood = new ArchVirtue("FaerieBlood", "FaerieBlood", VirtueType.General, VirtueMajorMinor.MINOR);
+        public static ArchVirtue Famous = new ArchVirtue("Famous", "Famous", VirtueType.General, VirtueMajorMinor.MINOR);
+        public static ArchVirtue FreeExpression = new ArchVirtue("FreeExpression", "FreeExpression", VirtueType.General, VirtueMajorMinor.MINOR);
+        public static ArchVirtue GoodTeacher = new ArchVirtue("GoodTeacher", "GoodTeacher", VirtueType.General, VirtueMajorMinor.MINOR);
+        public static ArchVirtue Gossip = new ArchVirtue("Gossip", "Gossip", VirtueType.General, VirtueMajorMinor.MINOR);
+        public static ArchVirtue ImprovedCharacteristics = new ArchVirtue("ImprovedCharacteristics", "ImprovedCharacteristics", VirtueType.General, VirtueMajorMinor.MINOR);
+        public static ArchVirtue Inspirational = new ArchVirtue("Inspirational", "Inspirational", VirtueType.General, VirtueMajorMinor.MINOR);
+        public static ArchVirtue Intuition = new ArchVirtue("Intuition", "Intuition", VirtueType.General, VirtueMajorMinor.MINOR);
+        public static ArchVirtue KeenVision = new ArchVirtue("KeenVision", "KeenVision", VirtueType.General, VirtueMajorMinor.MINOR);
+        public static ArchVirtue Large = new ArchVirtue("Large", "Large", VirtueType.General, VirtueMajorMinor.MINOR);
+        public static ArchVirtue LatentMagicalAbility = new ArchVirtue("LatentMagicalAbility", "LatentMagicalAbility", VirtueType.General, VirtueMajorMinor.MINOR);
+        public static ArchVirtue LearnAbilityfromMistakes = new ArchVirtue("Learn(Ability)fromMistakes", "Learn(Ability)fromMistakes", VirtueType.General, VirtueMajorMinor.MINOR);
+        public static ArchVirtue LightTouch = new ArchVirtue("LightTouch", "LightTouch", VirtueType.General, VirtueMajorMinor.MINOR);
+        public static ArchVirtue LightningReflexes = new ArchVirtue("LightningReflexes", "LightningReflexes", VirtueType.General, VirtueMajorMinor.MINOR);
+        public static ArchVirtue LongWinded = new ArchVirtue("Long-Winded", "Long-Winded", VirtueType.General, VirtueMajorMinor.MINOR);
+        public static ArchVirtue Luck = new ArchVirtue("Luck", "Luck", VirtueType.General, VirtueMajorMinor.MINOR);
+        public static ArchVirtue RapidConvalescence = new ArchVirtue("RapidConvalescence", "RapidConvalescence", VirtueType.General, VirtueMajorMinor.MINOR);
+        public static ArchVirtue PerfectBalance = new ArchVirtue("PerfectBalance", "PerfectBalance", VirtueType.General, VirtueMajorMinor.MINOR);
+        public static ArchVirtue PiercingGaze = new ArchVirtue("PiercingGaze", "PiercingGaze", VirtueType.General, VirtueMajorMinor.MINOR);
+        public static ArchVirtue PrivilegedUpbringing = new ArchVirtue("PrivilegedUpbringing", "PrivilegedUpbringing", VirtueType.General, VirtueMajorMinor.MINOR);
+        public static ArchVirtue Protection = new ArchVirtue("Protection", "Protection", VirtueType.General, VirtueMajorMinor.MINOR);
+        public static ArchVirtue PuissantAbility = new ArchVirtue("PuissantAbility", "PuissantAbility", VirtueType.General, VirtueMajorMinor.MINOR);
+        public static ArchVirtue Relic = new ArchVirtue("Relic", "Relic", VirtueType.General, VirtueMajorMinor.MINOR);
+        public static ArchVirtue ReservesofStrength = new ArchVirtue("ReservesofStrength", "ReservesofStrength", VirtueType.General, VirtueMajorMinor.MINOR);
+        public static ArchVirtue SelfConfident = new ArchVirtue("Self-Confident", "Self-Confident", VirtueType.General, VirtueMajorMinor.MINOR);
+        public static ArchVirtue SharpEars = new ArchVirtue("SharpEars", "SharpEars", VirtueType.General, VirtueMajorMinor.MINOR);
+        public static ArchVirtue SocialContacts = new ArchVirtue("SocialContacts", "SocialContacts", VirtueType.General, VirtueMajorMinor.MINOR);
+        public static ArchVirtue StrongWilled = new ArchVirtue("Strong-Willed", "Strong-Willed", VirtueType.General, VirtueMajorMinor.MINOR);
+        public static ArchVirtue StudentofRealm = new ArchVirtue("Studentof(Realm)", "Studentof(Realm)", VirtueType.General, VirtueMajorMinor.MINOR);
+        public static ArchVirtue TemporalInfluence = new ArchVirtue("TemporalInfluence", "TemporalInfluence", VirtueType.General, VirtueMajorMinor.MINOR);
+        public static ArchVirtue Tough = new ArchVirtue("Tough", "Tough", VirtueType.General, VirtueMajorMinor.MINOR);
+        public static ArchVirtue TroupeUpbringing = new ArchVirtue("TroupeUpbringing", "TroupeUpbringing", VirtueType.General, VirtueMajorMinor.MINOR);
+        public static ArchVirtue TrueLovePC = new ArchVirtue("TrueLove(PC)", "TrueLove(PC)", VirtueType.General, VirtueMajorMinor.MINOR);
+        public static ArchVirtue Unaging = new ArchVirtue("Unaging", "Unaging", VirtueType.General, VirtueMajorMinor.MINOR);
+        public static ArchVirtue VenusBlessing = new ArchVirtue("Venus’Blessing", "Venus’Blessing", VirtueType.General, VirtueMajorMinor.MINOR);
+        public static ArchVirtue Warrior = new ArchVirtue("Warrior", "Warrior", VirtueType.General, VirtueMajorMinor.MINOR);
+        public static ArchVirtue WellTraveled = new ArchVirtue("Well-Traveled", "Well-Traveled", VirtueType.General, VirtueMajorMinor.MINOR);
+        
+        // Social Free
+        public static ArchVirtue Covenfolk = new ArchVirtue("Covenfolk", "Covenfolk", VirtueType.Social, VirtueMajorMinor.FREE);
+        public static ArchVirtue Craftsman = new ArchVirtue("Craftsman", "Craftsman", VirtueType.Social, VirtueMajorMinor.FREE);
+        public static ArchVirtue HermeticMagus = new ArchVirtue("HermeticMagus", "HermeticMagus", VirtueType.Social, VirtueMajorMinor.FREE);
+        public static ArchVirtue Merchant = new ArchVirtue("Merchant", "Merchant", VirtueType.Social, VirtueMajorMinor.FREE);
+        public static ArchVirtue Peasant = new ArchVirtue("Peasant", "Peasant", VirtueType.Social, VirtueMajorMinor.FREE);
+        public static ArchVirtue Wanderer = new ArchVirtue("Wanderer", "Wanderer", VirtueType.Social, VirtueMajorMinor.FREE);
+    }
+}

--- a/WizardMakerTestbed/Models/Virtues/VirtueCommands/PuissantAbilityCommand.cs
+++ b/WizardMakerTestbed/Models/Virtues/VirtueCommands/PuissantAbilityCommand.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace WizardMakerPrototype.Models.Virtues.VirtueCommands
+{
+    public class PuissantAbilityCommand : ICharacterCommand
+    {
+        ArchAbility ability;
+        
+        public PuissantAbilityCommand(ArchAbility ability)
+        {
+            this.ability = ability;
+        }
+
+        public void Execute(Character cb)
+        {
+            cb.puissantAbilities.Add(ability.Name);
+        }
+
+        public void Undo()
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/WizardMakerTestbed/Models/Virtues/VirtueCommands/WealthyCommand.cs
+++ b/WizardMakerTestbed/Models/Virtues/VirtueCommands/WealthyCommand.cs
@@ -8,12 +8,12 @@ namespace WizardMakerPrototype.Models.Virtues.VirtueCommands
 {
     public class WealthyCommand : ICharacterCommand
     {
+        public static int WEALTHY_XP = 20;
         public void Execute(Character cb)
         {
-            cb.XpPerSeasonForInitialCreation = 20;
-
-            // TODO: Increase the BasicXPPool
-            
+            // Since this is executed before the XP Pool initialization, the wealthy will carry over for initial characters.
+            //  And this will also work for characters that acquire wealthy later on, due to the SeasonYear attached to the virtue.
+            cb.XpPerYear = WEALTHY_XP;
         }
 
         public void Undo()

--- a/WizardMakerTestbed/Models/Virtues/VirtueCommands/WealthyCommand.cs
+++ b/WizardMakerTestbed/Models/Virtues/VirtueCommands/WealthyCommand.cs
@@ -11,7 +11,8 @@ namespace WizardMakerPrototype.Models.Virtues.VirtueCommands
         public static int WEALTHY_XP = 20;
         public void Execute(Character cb)
         {
-            // Since this is executed before the XP Pool initialization, the wealthy will carry over for initial characters.
+            // Since this is executed before the XP Pool initialization, the wealthy will carry over for initial characters (so long as the developers do a good job with
+            //  making sure that both journal entries have the same season-year.
             //  And this will also work for characters that acquire wealthy later on, due to the SeasonYear attached to the virtue.
             cb.XpPerYear = WEALTHY_XP;
         }

--- a/WizardMakerTestbed/Models/Virtues/VirtueCommands/WealthyCommand.cs
+++ b/WizardMakerTestbed/Models/Virtues/VirtueCommands/WealthyCommand.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace WizardMakerPrototype.Models.Virtues.VirtueCommands
+{
+    public class WealthyCommand : ICharacterCommand
+    {
+        public void Execute(Character cb)
+        {
+            cb.XpPerSeasonForInitialCreation = 20;
+
+            // TODO: Increase the BasicXPPool
+            
+        }
+
+        public void Undo()
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/WizardMakerTestbed/Models/Virtues/VirtueInstance.cs
+++ b/WizardMakerTestbed/Models/Virtues/VirtueInstance.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace WizardMakerPrototype.Models.Virtues
+{
+    public class VirtueInstance
+    {
+        public ArchVirtue Virtue { get; private set;}
+        public VirtueInstance(ArchVirtue virtue)
+        {
+            Virtue = virtue;
+        }
+    }
+}

--- a/WizardMakerTestbed/WizardMakerTestbed.csproj
+++ b/WizardMakerTestbed/WizardMakerTestbed.csproj
@@ -110,10 +110,12 @@
     <Compile Include="Models\InvalidCharacterInitializationException.cs" />
     <Compile Include="Models\Journal\Journalable.cs" />
     <Compile Include="Models\CharacterPersist\RawCharacter.cs" />
+    <Compile Include="Models\Journal\JournalSortingConstants.cs" />
     <Compile Include="Models\ShouldNotBeAbleToGetHereException.cs" />
     <Compile Include="Models\Journal\SimpleJournalEntry.cs" />
     <Compile Include="Models\Journal\XpAbilitySpendJournalEntry.cs" />
     <Compile Include="Models\Virtues\ArchVirtue.cs" />
+    <Compile Include="Models\Virtues\VirtueCommands\WealthyCommand.cs" />
     <Compile Include="Models\Virtues\VirtueInstance.cs" />
     <Compile Include="Models\XPPool.cs" />
     <Compile Include="Models\Journal\NewCharacterInitJournalEntry.cs" />

--- a/WizardMakerTestbed/WizardMakerTestbed.csproj
+++ b/WizardMakerTestbed/WizardMakerTestbed.csproj
@@ -98,6 +98,7 @@
     <Compile Include="Models\AbilityModels.cs" />
     <Compile Include="Models\AbilityNotFoundException.cs" />
     <Compile Include="Models\AbilityXPManager.cs" />
+    <Compile Include="Models\Journal\AddVirtueJournalEntry.cs" />
     <Compile Include="Models\Journal\BasicJournalableManager.cs" />
     <Compile Include="Models\Character.cs" />
     <Compile Include="Models\CharacterManager.cs" />
@@ -110,8 +111,10 @@
     <Compile Include="Models\Journal\Journalable.cs" />
     <Compile Include="Models\CharacterPersist\RawCharacter.cs" />
     <Compile Include="Models\ShouldNotBeAbleToGetHereException.cs" />
-    <Compile Include="Models\Journal\SingleJournalEntry.cs" />
+    <Compile Include="Models\Journal\SimpleJournalEntry.cs" />
     <Compile Include="Models\Journal\XpAbilitySpendJournalEntry.cs" />
+    <Compile Include="Models\Virtues\ArchVirtue.cs" />
+    <Compile Include="Models\Virtues\VirtueInstance.cs" />
     <Compile Include="Models\XPPool.cs" />
     <Compile Include="Models\Journal\NewCharacterInitJournalEntry.cs" />
     <Compile Include="Models\XPPoolOverdrawnException.cs" />

--- a/WizardMakerTestbed/WizardMakerTestbed.csproj
+++ b/WizardMakerTestbed/WizardMakerTestbed.csproj
@@ -115,6 +115,7 @@
     <Compile Include="Models\Journal\SimpleJournalEntry.cs" />
     <Compile Include="Models\Journal\XpAbilitySpendJournalEntry.cs" />
     <Compile Include="Models\Virtues\ArchVirtue.cs" />
+    <Compile Include="Models\Virtues\VirtueCommands\PuissantAbilityCommand.cs" />
     <Compile Include="Models\Virtues\VirtueCommands\WealthyCommand.cs" />
     <Compile Include="Models\Virtues\VirtueInstance.cs" />
     <Compile Include="Models\XPPool.cs" />

--- a/WizardMakerTests/Models/CharacterManagerTests.cs
+++ b/WizardMakerTests/Models/CharacterManagerTests.cs
@@ -54,7 +54,7 @@ namespace WizardMakerPrototype.Models.Tests
         public void SimpleRoundTripFileTest()
         {
             Character c = new("Foo", "Looks like a foo", 25);
-            NewCharacterInitJournalEntry initEntry = new NewCharacterInitJournalEntry(25, ArchAbility.LangEnglish, 15);
+            NewCharacterInitJournalEntry initEntry = new NewCharacterInitJournalEntry(25, ArchAbility.LangEnglish);
             c.addJournalable(initEntry);
 
             string tempPath = Path.GetTempFileName();

--- a/WizardMakerTests/Models/CharacterRendererTests.cs
+++ b/WizardMakerTests/Models/CharacterRendererTests.cs
@@ -49,12 +49,11 @@ namespace WizardMakerTests.Models
         {
             Random rnd = new Random(1212);
             const int STARTING_AGE = 25;
-            const int XP_PER_SEASON = 20;
 
             // Look at the timing for rendering an entire character.
             Character c = new("Foo", "Best mage ever.  They really know a lot.", STARTING_AGE);
 
-            NewCharacterInitJournalEntry initEntry = new NewCharacterInitJournalEntry(STARTING_AGE, ArchAbility.LangEnglish, XP_PER_SEASON);
+            NewCharacterInitJournalEntry initEntry = new NewCharacterInitJournalEntry(STARTING_AGE, ArchAbility.LangEnglish);
             c.addJournalable(initEntry);
 
             Dictionary<string, int> xpSpentMap = new Dictionary<string, int>();

--- a/WizardMakerTests/Models/CharacterRendererTests.cs
+++ b/WizardMakerTests/Models/CharacterRendererTests.cs
@@ -4,6 +4,8 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using WizardMakerPrototype.Models;
+using WizardMakerPrototype.Models.Journal;
+using WizardMakerPrototype.Models.Virtues;
 
 namespace WizardMakerTests.Models
 {
@@ -13,6 +15,32 @@ namespace WizardMakerTests.Models
         private const string XP_POOL_NAME = "dummy";
         private const string XP_POOL_DESCRIPTION = "dummy XP Pool";
         private const int XP_POOL_INITIAL_XP = 500;
+
+        [TestMethod]
+        public void RenderTwiceTest()
+        {
+            int STARTING_AGE = 25;
+            int SAGA_START = 1220;
+            SeasonYear initSeasonYear = new SeasonYear(SAGA_START - STARTING_AGE, Season.SPRING);
+            // Create a wealthy character
+            Character c = new("Foo", "Looks like a wealthy foo", STARTING_AGE);
+            NewCharacterInitJournalEntry initEntry = new NewCharacterInitJournalEntry(25, ArchAbility.LangEnglish);
+            AddVirtueJournalEntry addVirtueJournalEntry = new AddVirtueJournalEntry(initSeasonYear, ArchVirtue.Wealthy);
+            c.addJournalable(initEntry);
+            c.addJournalable(addVirtueJournalEntry);
+            c.addJournalable(new XpAbilitySpendJournalEntry("Ability spend Brawl", initSeasonYear, "Brawl", 25, "Fists"));
+            CharacterRenderer.renderAllJournalEntries(c);
+            int initialXPPoolCount = c.XPPoolList.Count;
+            int initialXPSpend = c.totalRemainingXPWithoutOverdrawn();
+            Assert.AreEqual(1, c.abilities.Count);
+            Assert.AreEqual(1, c.virtues.Count);
+
+            // Render again and see that counts do not change
+            Assert.AreEqual(1, c.abilities.Count);
+            Assert.AreEqual(1, c.virtues.Count);
+            Assert.AreEqual(initialXPPoolCount, c.XPPoolList.Count);
+            Assert.AreEqual(initialXPSpend, c.totalRemainingXPWithoutOverdrawn());
+        }
 
         // We expect the results going in to be the same as coming out.
         [DataTestMethod()]

--- a/WizardMakerTests/Models/CharacterRendererTests.cs
+++ b/WizardMakerTests/Models/CharacterRendererTests.cs
@@ -25,7 +25,7 @@ namespace WizardMakerTests.Models
             // Create a wealthy character
             Character c = new("Foo", "Looks like a wealthy foo", STARTING_AGE);
             NewCharacterInitJournalEntry initEntry = new NewCharacterInitJournalEntry(25, ArchAbility.LangEnglish);
-            AddVirtueJournalEntry addVirtueJournalEntry = new AddVirtueJournalEntry(initSeasonYear, ArchVirtue.Wealthy);
+            AddVirtueJournalEntry addVirtueJournalEntry = new AddVirtueJournalEntry(initSeasonYear, ArchVirtue.NameToArchVirtue["Wealthy"]);
             c.addJournalable(initEntry);
             c.addJournalable(addVirtueJournalEntry);
             c.addJournalable(new XpAbilitySpendJournalEntry("Ability spend Brawl", initSeasonYear, "Brawl", 25, "Fists"));

--- a/WizardMakerTests/Models/Journal/BasicJournalableManagerTests.cs
+++ b/WizardMakerTests/Models/Journal/BasicJournalableManagerTests.cs
@@ -28,7 +28,7 @@ namespace WizardMakerTests.Models.Journal
             };
             for (int i = 0; i < seasonYears.Length; i++)
             {
-                journalableManager.addJournalable(new SingleJournalEntry("Random entry " + i, seasonYears[i]));
+                journalableManager.addJournalable(new SimpleJournalEntry("Random entry " + i, seasonYears[i]));
             }
             SortedSet<Journalable> journalables = journalableManager.getJournalables();
             Assert.AreEqual(seasonYears.Length, journalables.Count);
@@ -49,7 +49,7 @@ namespace WizardMakerTests.Models.Journal
             string idToRemove = "THIS IS DEFINITELY WRONG";
             for (int i = 0; i < 4; i++)
             {
-                SingleJournalEntry journalable = new SingleJournalEntry(TEST_STRING + i, new SeasonYear(1220, Season.SPRING));
+                SimpleJournalEntry journalable = new SimpleJournalEntry(TEST_STRING + i, new SeasonYear(1220, Season.SPRING));
                 journalableManager.addJournalable(journalable);
                 if (i == 2)
                 {

--- a/WizardMakerTests/Models/Journal/NewCharacterInitJournalEntryTest.cs
+++ b/WizardMakerTests/Models/Journal/NewCharacterInitJournalEntryTest.cs
@@ -16,7 +16,7 @@ namespace WizardMakerTests.Models.Journal
         public void SimpleInitTest()
         {
             Character c = new Character("New Character", "Test new character", new List<AbilityInstance>(), new List<Journalable>(), 25);
-            NewCharacterInitJournalEntry NewCharacterInitJournalEntry = new NewCharacterInitJournalEntry(25, ArchAbility.LangEnglish, 15);
+            NewCharacterInitJournalEntry NewCharacterInitJournalEntry = new NewCharacterInitJournalEntry(25, ArchAbility.LangEnglish);
 
             // Normally, call cm.renderAllJournalEntries(), rather than executing the journal entry directly.
             NewCharacterInitJournalEntry.Execute(c);
@@ -34,8 +34,9 @@ namespace WizardMakerTests.Models.Journal
         public void XpPerSeasonTest(int xpPerSeason, int startingAge)
         {
             Character c = new Character("New Character", "Test new character", new List<AbilityInstance>(), new List<Journalable>(), startingAge);
+            c.XpPerYear = xpPerSeason;
 
-            NewCharacterInitJournalEntry NewCharacterInitJournalEntry = new NewCharacterInitJournalEntry(startingAge, ArchAbility.LangEnglish, xpPerSeason);
+            NewCharacterInitJournalEntry NewCharacterInitJournalEntry = new NewCharacterInitJournalEntry(startingAge, ArchAbility.LangEnglish);
 
             // Normally, call cm.renderAllJournalEntries(), rather than executing the journal entry directly.
             NewCharacterInitJournalEntry.Execute(c);
@@ -50,9 +51,8 @@ namespace WizardMakerTests.Models.Journal
         public void SerializableTest()
         {
             const int startingAge = 25;
-            const int xpPerSeason = 10;
 
-            Journalable entry = new NewCharacterInitJournalEntry(startingAge, ArchAbility.LangEnglish, xpPerSeason);
+            Journalable entry = new NewCharacterInitJournalEntry(startingAge, ArchAbility.LangEnglish);
 
             string tmp = entry.SerializeJson();
             Journalable deserialized = Journalable.DeserializeJson(tmp);

--- a/WizardMakerTests/Models/Journal/SingleJournalEntryTests.cs
+++ b/WizardMakerTests/Models/Journal/SingleJournalEntryTests.cs
@@ -14,7 +14,7 @@ namespace WizardMakerPrototype.Models.Tests
         [TestMethod()]
         public void SingleJournalEntryTest()
         {
-            Journalable entry = new SingleJournalEntry("Test Entry", new SeasonYear(1222, Season.SPRING));
+            Journalable entry = new SimpleJournalEntry("Test Entry", new SeasonYear(1222, Season.SPRING));
             Assert.IsNotNull(entry);
         }
 
@@ -22,7 +22,7 @@ namespace WizardMakerPrototype.Models.Tests
         public void getTextTest()
         {
             const string TITLE = "New Entry";
-            Journalable entry = new SingleJournalEntry(TITLE, new SeasonYear(1222, Season.SPRING));
+            Journalable entry = new SimpleJournalEntry(TITLE, new SeasonYear(1222, Season.SPRING));
             Assert.IsNotNull(entry);
             Assert.AreEqual(TITLE, entry.getText());
         }
@@ -32,7 +32,7 @@ namespace WizardMakerPrototype.Models.Tests
         {
             const string TITLE = "New Entry";
             SeasonYear sy = new SeasonYear(1222, Season.SPRING);
-            Journalable entry = new SingleJournalEntry(TITLE, sy);
+            Journalable entry = new SimpleJournalEntry(TITLE, sy);
             Assert.IsNotNull(entry);
             Assert.AreEqual(sy, entry.getDate());
         }
@@ -44,7 +44,7 @@ namespace WizardMakerPrototype.Models.Tests
             const string TITLE = "New Entry";
             SeasonYear sy = new SeasonYear(1222, Season.SPRING);
             Character dummy = new Character("My name", "My desription", 30);
-            Journalable entry = new SingleJournalEntry(TITLE, sy);
+            Journalable entry = new SimpleJournalEntry(TITLE, sy);
             entry.Execute(dummy);
         }
 
@@ -52,7 +52,7 @@ namespace WizardMakerPrototype.Models.Tests
         public void getIdTest()
         {
             // Test that the IDs actually change when you deserialize a SingleJournalEntry
-            Journalable entry = new SingleJournalEntry("Test Entry", new SeasonYear(1222, Season.SPRING));
+            Journalable entry = new SimpleJournalEntry("Test Entry", new SeasonYear(1222, Season.SPRING));
 
             string tmp = entry.SerializeJson();
             Journalable deserialized = Journalable.DeserializeJson(tmp);
@@ -71,7 +71,7 @@ namespace WizardMakerPrototype.Models.Tests
         public void SerializableTest()
         {
 
-            Journalable entry = new SingleJournalEntry("Test Entry", new SeasonYear(1222, Season.SPRING));
+            Journalable entry = new SimpleJournalEntry("Test Entry", new SeasonYear(1222, Season.SPRING));
 
             string tmp = entry.SerializeJson();
             Journalable deserialized = Journalable.DeserializeJson(tmp);

--- a/WizardMakerTests/Models/Journal/XpAbilitySpendJournalEntryTests.cs
+++ b/WizardMakerTests/Models/Journal/XpAbilitySpendJournalEntryTests.cs
@@ -49,7 +49,7 @@ namespace WizardMakerPrototype.Models.Tests
             Journalable entry = new XpAbilitySpendJournalEntry(Expected, sy, "Brawl", 5, "Fists");
 
             // Initialize the character before attempting to buy an ability
-            Journalable initEntry = new NewCharacterInitJournalEntry(25, ArchAbility.LangEnglish, 20);
+            Journalable initEntry = new NewCharacterInitJournalEntry(25, ArchAbility.LangEnglish);
             initEntry.Execute(dummy);
 
             // Now actually test the XP spend

--- a/WizardMakerTests/Models/Virtues/VirtueCommands/PuissantAbilityCommandTests.cs
+++ b/WizardMakerTests/Models/Virtues/VirtueCommands/PuissantAbilityCommandTests.cs
@@ -1,0 +1,42 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using WizardMakerPrototype.Models.Virtues.VirtueCommands;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using WizardMakerPrototype.Models.Journal;
+
+namespace WizardMakerPrototype.Models.Virtues.VirtueCommands.Tests
+{
+    [TestClass()]
+    public class PuissantAbilityCommandTests
+    {
+        [TestMethod()]
+        public void ExecuteSimpleTest()
+        {
+            int STARTING_AGE = 25;
+            int SAGA_START = 1220;
+            string ABILITY = "Brawl";
+            // Create a wealthy character
+            Character c = new("Foo", "Looks like a wealthy foo", STARTING_AGE);
+            NewCharacterInitJournalEntry initEntry = new NewCharacterInitJournalEntry(25, ArchAbility.LangEnglish);
+            AddVirtueJournalEntry addVirtueJournalEntry = new AddVirtueJournalEntry(new SeasonYear(SAGA_START - STARTING_AGE, Season.SPRING),
+                ArchVirtue.NameToArchVirtue[ArchVirtue.PUISSANT_PREFIX + ABILITY]);
+            XpAbilitySpendJournalEntry xpSpend = new XpAbilitySpendJournalEntry("XP spent on Brawl", new SeasonYear(SAGA_START - STARTING_AGE, Season.SPRING), ABILITY, 15, "Fist");
+            c.addJournalable(initEntry);
+            c.addJournalable(addVirtueJournalEntry);
+            c.addJournalable(xpSpend);
+            CharacterRenderer.renderAllJournalEntries(c);
+
+            Assert.IsTrue(c.abilities.Where(a => a.Name == ABILITY).First().HasPuissance);
+
+            // Please note that we still treat the score as if it was 2, not 4.  This is because we need to render it later as "2+2", not "4".
+            Assert.AreEqual(2, c.abilities.Where(a => a.Name == ABILITY).First().Score);
+
+            
+        }
+
+        // TODO: Add test where no XP has been spent
+    }
+}

--- a/WizardMakerTests/Models/Virtues/VirtueCommands/WealthyCommandTests.cs
+++ b/WizardMakerTests/Models/Virtues/VirtueCommands/WealthyCommandTests.cs
@@ -21,7 +21,7 @@ namespace WizardMakerPrototype.Models.Virtues.VirtueCommands.Tests
             // Create a wealthy character
             Character c = new("Foo", "Looks like a wealthy foo", STARTING_AGE);
             NewCharacterInitJournalEntry initEntry = new NewCharacterInitJournalEntry(25, ArchAbility.LangEnglish);
-            AddVirtueJournalEntry addVirtueJournalEntry = new AddVirtueJournalEntry(new SeasonYear(SAGA_START-STARTING_AGE, Season.SPRING), ArchVirtue.Wealthy);
+            AddVirtueJournalEntry addVirtueJournalEntry = new AddVirtueJournalEntry(new SeasonYear(SAGA_START-STARTING_AGE, Season.SPRING), ArchVirtue.NameToArchVirtue["Wealthy"]);
             c.addJournalable(initEntry);
             c.addJournalable(addVirtueJournalEntry);
             CharacterRenderer.renderAllJournalEntries(c);

--- a/WizardMakerTests/Models/Virtues/VirtueCommands/WealthyCommandTests.cs
+++ b/WizardMakerTests/Models/Virtues/VirtueCommands/WealthyCommandTests.cs
@@ -17,18 +17,29 @@ namespace WizardMakerPrototype.Models.Virtues.VirtueCommands.Tests
         {
             int STARTING_AGE = 25;
             int SAGA_START = 1220;
+            
             // Create a wealthy character
-            Character c = new("Foo", "Looks like a foo", STARTING_AGE);
-            NewCharacterInitJournalEntry initEntry = new NewCharacterInitJournalEntry(25, ArchAbility.LangEnglish, 15);
+            Character c = new("Foo", "Looks like a wealthy foo", STARTING_AGE);
+            NewCharacterInitJournalEntry initEntry = new NewCharacterInitJournalEntry(25, ArchAbility.LangEnglish);
             AddVirtueJournalEntry addVirtueJournalEntry = new AddVirtueJournalEntry(new SeasonYear(SAGA_START-STARTING_AGE, Season.SPRING), ArchVirtue.Wealthy);
             c.addJournalable(initEntry);
             c.addJournalable(addVirtueJournalEntry);
             CharacterRenderer.renderAllJournalEntries(c);
 
-            // Assert that the character has 20 XP and that the Later Life XP is updated accordingly.
-            Assert.AreEqual(20, c.XpPerSeasonForInitialCreation);
+            // Assert that the wealthy virtue appears before the new character init
+            Assert.AreEqual(addVirtueJournalEntry, c.GetJournal().ElementAt(0));
+            Assert.AreEqual(initEntry, c.GetJournal().ElementAt(1));
 
-            
+            // Assert that the character has 20 XP and that the Later Life XP is updated accordingly.
+            Assert.AreEqual(WealthyCommand.WEALTHY_XP, c.XpPerYear);
+
+            foreach (XPPool xppool in c.XPPoolList)
+            {
+                if (xppool.name.Equals(NewCharacterInitJournalEntry.LATER_LIFE_POOL_NAME))
+                {
+                    Assert.AreEqual((STARTING_AGE - NewCharacterInitJournalEntry.CHILDHOOD_END_AGE) * WealthyCommand.WEALTHY_XP, xppool.initialXP);
+                }
+            }
         }
     }
 }

--- a/WizardMakerTests/Models/Virtues/VirtueCommands/WealthyCommandTests.cs
+++ b/WizardMakerTests/Models/Virtues/VirtueCommands/WealthyCommandTests.cs
@@ -1,0 +1,34 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using WizardMakerPrototype.Models.Virtues.VirtueCommands;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using WizardMakerPrototype.Models.Journal;
+
+namespace WizardMakerPrototype.Models.Virtues.VirtueCommands.Tests
+{
+    [TestClass()]
+    public class WealthyCommandTests
+    {
+        [TestMethod()]
+        public void ExecuteTest()
+        {
+            int STARTING_AGE = 25;
+            int SAGA_START = 1220;
+            // Create a wealthy character
+            Character c = new("Foo", "Looks like a foo", STARTING_AGE);
+            NewCharacterInitJournalEntry initEntry = new NewCharacterInitJournalEntry(25, ArchAbility.LangEnglish, 15);
+            AddVirtueJournalEntry addVirtueJournalEntry = new AddVirtueJournalEntry(new SeasonYear(SAGA_START-STARTING_AGE, Season.SPRING), ArchVirtue.Wealthy);
+            c.addJournalable(initEntry);
+            c.addJournalable(addVirtueJournalEntry);
+            CharacterRenderer.renderAllJournalEntries(c);
+
+            // Assert that the character has 20 XP and that the Later Life XP is updated accordingly.
+            Assert.AreEqual(20, c.XpPerSeasonForInitialCreation);
+
+            
+        }
+    }
+}


### PR DESCRIPTION
- Created ArchVirtue and Virtue Instance in a similar manner to Abilities.  One difference though is that accessing instances of ArchVirtue is done through a static dictionary, not through instances.  This allows access via strings.  Some cleanup is still needed, but this makes creating static instances of sub-virtues (eg, Puissant <Ability>) without reflection.
- Virtues run character commands (ICharacterCommand) similar to journal entries.  So the journal entry will add the virtue instance to a character and then run it on the character.
- Implemented sorting of journal entries by their class, so that Virtues will be sorted before Character Init and other journal entries when the SeasonYear is the same.
- Implemented Wealthy Virtue
- Implemented Puissant Ability Virtue.  Note that this is actually many virtues.  Each is treated as a separate virtue.
- Added tests
- NewCharacterInitJournalEntry no longer owns the XpPerYear.  That is now in the Character, and can be set by a virtue (eg, Wealthy)